### PR TITLE
docs: allinea funnel e setup locale

### DIFF
--- a/.github/ISSUE_TEMPLATE/dataset-funnel.yml
+++ b/.github/ISSUE_TEMPLATE/dataset-funnel.yml
@@ -1,0 +1,90 @@
+name: Dataset journey (funnel)
+description: Traccia un filone dataset end-to-end nella Open Board del Lab.
+title: "dataset: [SLUG]"
+labels: ["dataset", "funnel"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Utilizza questa issue come **Issue Madre** per tracciare il percorso di un dataset nel Lab, dallo scouting iniziale alla pubblicazione.
+        Questa issue non sostituisce il lavoro tecnico (che vive in `dataset-incubator`) ma serve a consolidare il progresso nella Open Board.
+
+  - type: input
+    id: slug
+    attributes:
+      label: Slug
+      description: Lo slug canonico del dataset (es. `istat-abitazioni-affitto-2023`).
+      placeholder: es. istat-abitazioni-affitto-2023
+    validations:
+      required: true
+
+  - type: textarea
+    id: civic_question
+    attributes:
+      label: Domanda civica
+      description: Qual e' la domanda pubblica o il gap che guida questo filone?
+      placeholder: Formula la domanda in modo chiaro e analitico.
+    validations:
+      required: true
+
+  - type: input
+    id: source
+    attributes:
+      label: Fonte o dataset
+      description: Nome della fonte principale (es. ISTAT SDMX, ISPRA RDF, OpenBDAP).
+    validations:
+      required: true
+
+  - type: dropdown
+    id: phase
+    attributes:
+      label: Fase attuale
+      description: Seleziona la fase corrente del funnel.
+      options:
+        - "1. SCOUTING (source-check)"
+        - "2. VALIDATION (Reddit/Social signal)"
+        - "3. CONSOLIDATION (GitHub Discussion)"
+        - "4. INCUBATION (dataset-incubator)"
+        - "5. ANALYSIS (analisi/findings)"
+        - "6. PROMOTION (data-explorer - opzionale)"
+        - "WATCHLIST"
+        - "BLOCKED"
+        - "NO-GO"
+    validations:
+      required: true
+
+  - type: textarea
+    id: links
+    attributes:
+      label: Link utili
+      description: Incolla i link agli artifact man mano che vengono creati.
+      placeholder: |
+        - Source-check (nota locale):
+        - Validation (post Reddit):
+        - Discussion (GitHub):
+        - Issue Intake (DI):
+        - PR Candidate (DI):
+        - Analisi (folder/PR):
+        - Explorer:
+    validations:
+      required: false
+
+  - type: textarea
+    id: note
+    attributes:
+      label: Nota breve
+      description: Solo se serve a spiegare blocchi, scelte o cambi di rotta.
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        **Guida alle skill del Lab**
+        - **SCOUTING**: usa la skill `source-check` per il primo audit tecnico.
+        - **VALIDATION**: usa draft Reddit o altri segnali esterni quando serve; non sempre e' obbligatoria.
+        - **CONSOLIDATION**: usa la skill `open-discussion` per creare l'artifact canonico.
+        - **INCUBATION**: usa la skill `intake-candidate` per il lavoro tecnico in DI.
+        - **ANALYSIS**: usa la skill `promote-analisi` per il layer narrativo.
+        - **PROMOTION**: usa la skill `add-to-explorer` per il catalogo pubblico.

--- a/docs/dataset-project-flow.md
+++ b/docs/dataset-project-flow.md
@@ -1,176 +1,104 @@
 # Flusso dataset / progetto
 
-Questa pagina descrive il flusso canonico del Lab per trasformare una domanda civica in un progetto dati leggibile, verificabile e — se il lavoro lo giustifica — promosso a repo dedicata.
+Questa pagina descrive il funnel canonico del Lab per trasformare un segnale o una domanda civica in un progetto dati leggibile, verificabile e, se il lavoro lo giustifica, promosso al catalogo pubblico.
 
-## Vista rapida
+## Vista rapida (Funnel v0)
 
 ```text
-Domanda civica
-  -> Discussion
-  -> issue operativa
-  -> dataset-incubator (contratto tecnico: dataset.yml, sql, pipeline)
-  -> dataciviclab/analisi (layer pubblico: README, notebook, Discussion)
-  -> [solo se giustificato] repo dedicata dal project-template
+1. SCOUTING   (source-check)
+  -> 2. VALIDATION (Reddit/Social - opzionale)
+    -> 3. CONSOLIDATION (GitHub Discussion)
+      -> 4. INCUBATION (dataset-incubator: contratto tecnico)
+        -> 5. ANALYSIS (analisi/findings: layer pubblico)
+          -> 6. PROMOTION (data-explorer: catalogo - opzionale)
 ```
 
-Non tutti i filoni passano da ogni step.
-La maggior parte vive in `analisi/` senza diventare mai una repo dedicata — e va bene cosi.
+Il percorso non e' una catena rigida, ma un funnel di selezione: non tutti i segnali diventano Discussion, non tutte le analisi finiscono in explorer.
 
 ## Regola pratica
 
-- `dataciviclab` e' l'hub pubblico: Discussions, task cross-repo, `analisi/`, `projects/`
-- `dataset-incubator` e' la casa permanente del contratto tecnico di ogni filone
-- `analisi/` e' la destinazione finale del layer pubblico: README civico, notebook leggibile, Discussion collegata
-- una repo dedicata nasce solo quando il filone richiede sviluppo continuativo e governance propria
+- **GitHub Discussion** e' l'**artifact canonico** di consolidamento: il posto dove le informazioni diventano stabili e referenziabili.
+- **Reddit / Social** sono i **sensori di segnale**: servono a testare la tensione civica di un tema prima di impegnare risorse GitHub, quando il caso lo richiede.
+- **dataset-incubator** e' la **casa tecnica**: conserva il contratto tecnico (`dataset.yml`, SQL, check) in modo permanente.
+- **analisi/** e' il **layer pubblico**: e' la destinazione finale per la maggior parte dei racconti del Lab.
 
-Il contratto tecnico (dataset.yml, sql/, pipeline) resta in `dataset-incubator` anche dopo la promozione in analisi/.
-Il layer pubblico (README, notebook) vive in `dataciviclab/analisi/`.
-Le due cose sono complementari, non alternative.
+---
 
-## Step 1: Discussion
+## Step 1: SCOUTING (source-check)
 
-Si parte da una domanda civica o da un tema pubblico abbastanza chiaro da meritare esplorazione.
+Si parte da una fonte o da un tema. Lo scouting tecnico serve ad assegnare un **verdict**.
+**Skill: `source-check`**
 
-La `Discussion` serve a:
-- formulare meglio la domanda
-- chiarire perche' conta
-- raccogliere primi dubbi, fonti e angoli possibili
-- capire se il tema ha abbastanza sostanza per diventare un filone
+Obiettivo: decidere se la fonte regge davvero su accesso, formato, domanda civica e rischio semantico.
 
-Output minimo:
-- una domanda leggibile
-- una prima ipotesi di fonte o dataset
-- un perimetro iniziale plausibile
+Esiti tipici:
 
-## Step 2: issue operativa
+- `go Discussion`
+- `aggiorna #N`
+- `watchlist`
+- `support dataset`
+- `no-go`
 
-Quando la domanda regge, va trasformata in una issue piccola e concreta.
+## Step 2: VALIDATION (segnale esterno)
 
-La issue serve a:
-- fissare il primo passo reale
-- evitare backlog vago
-- creare un punto di riferimento operativo
+Prima di aprire una Discussion su GitHub, possiamo testare l'interesse della community su Reddit o altri canali.
+**Formati consigliati: `Dataset Request` o `Question Check`**
 
-La prima issue non deve descrivere tutto il progetto.
-Deve solo dire qual e' il prossimo passo utile.
+Obiettivo: capire se la domanda civica genera risposte o interesse reale. Se il segnale e' debole, il tema puo' restare in `watchlist` locale senza appesantire il backlog GitHub.
 
-## Step 3: dataset-incubator — il contratto tecnico
+Nota: questo step e' opzionale, non obbligatorio per ogni dataset.
 
-`dataset-incubator` e' il luogo dove si costruisce e si stabilizza il contratto tecnico del filone.
+## Step 3: CONSOLIDATION (GitHub Discussion)
+
+Se il segnale e' positivo, oppure se il caso e' gia' abbastanza forte da consolidare direttamente, fissiamo tutto in una Discussion in `dataciviclab`.
+**Skill: `open-discussion`**
+
+Qui la domanda si fissa, le fonti si ordinano e il filone diventa un artifact pubblico condivisibile. Non e' il posto per chiedere "interessa?", ma per dire "ecco perche' questa pista merita attenzione".
+
+## Step 4: INCUBATION (dataset-incubator)
+
+Quando il perimetro v0 e' chiaro, il dataset entra formalmente in incubazione tecnica.
+**Skill: `intake-candidate`**
 
 Qui si lavora su:
+
 - `dataset.yml`
 - `sql/clean.sql`
 - `sql/mart.sql`
-- notebook `v0`
-- note di metodo
+- check minimi e note di metodo
 
-E' il posto giusto se:
-- la fonte e' ancora da verificare bene
-- il tracciato e' ambiguo o instabile
-- serve capire se il dataset regge davvero
-- il primo mart o notebook non e' ancora chiaro
+Output atteso: candidate o PR verde che garantisce la stabilita' tecnica del dato.
 
-Output minimo atteso:
-- run funzionante almeno sul perimetro iniziale
-- prima lettura che racconti qualcosa
-- decisione: archiviare, continuare o promuovere
+## Step 5: ANALYSIS (analisi/findings)
 
-Il contratto tecnico non esce mai da `dataset-incubator`.
-Anche dopo che il filone entra in `analisi/`, il riferimento tecnico resta li'.
+Il layer pubblico finale vive in `dataciviclab/analisi/<slug>/`.
+**Skill: `promote-analisi`**
 
-## Step 4: analisi/ — il layer pubblico
+Un filone entra in `analisi/` se il dato tecnico e' stabile e vogliamo pubblicare una lettura leggibile (README, notebook o finding). Per molti dataset, questo e' l'endpoint naturale del funnel.
 
-`dataciviclab/analisi/` e' la destinazione finale del layer pubblico dei filoni attivi.
+## Step 6: PROMOTION (data-explorer)
 
-Un filone entra in `analisi/` se ha:
-- una domanda civica chiara
-- una issue collegata a una Discussion
-- un output minimo atteso
-- un primo nucleo tecnico che regge in DI
-- abbastanza sostanza da meritare visibilita' pubblica
+Promozione al catalogo pubblico nazionale (`data-explorer`).
+**Skill: `add-to-explorer`**
 
-Cosa vive in `analisi/<slug>/`:
-- `README` con domanda, dataset, stato, link alla Discussion
-- notebook con lettura leggibile
-- eventuali note o asset leggeri
+Questo step e' opzionale: ha senso soprattutto se il dataset e' periodico, ha una domanda civica larga o e' un gap prioritario che merita una vista pubblica permanente.
 
-Cosa non vive in `analisi/`:
-- dataset.yml, sql/, pipeline — restano in dataset-incubator
-- dati grezzi o output tecnici
-
-Per la maggior parte dei filoni, `analisi/` e' l'endpoint.
-Non e' un gradino verso qualcosa di piu': e' gia' il posto giusto.
-
-## Step 5: quando nasce una repo dedicata (opzionale)
-
-Una repo dedicata e' giustificata solo in casi specifici.
-
-Segnali che la giustificano:
-- il filone coinvolge piu' dataset indipendenti con pipeline proprie
-- esiste un output periodico che richiede aggiornamento continuativo
-- la community ha raggiunto una dimensione che richiede governance propria
-- il backlog e' abbastanza ampio da non stare in una Issue
-
-Se questi segnali non ci sono, il filone resta in `analisi/`.
-Aprire una repo dedicata troppo presto e' dispersivo: aumenta la manutenzione e spezza la visibilita' senza aggiungere valore.
-
-Quando una repo nasce:
-- esce dal `project-template`
-- si collega alla Open Board
-- in `dataciviclab/projects/` resta una scheda leggera del progetto
-- la Discussion pubblica continua a vivere in `dataciviclab`
+---
 
 ## Due percorsi tipici
 
-### Percorso senza repo dedicata (la maggioranza)
+### 1. Percorso civico standard
 
-```text
-Discussion
-  -> issue
-  -> dataset-incubator (contratto tecnico)
-  -> analisi/ (layer pubblico, destinazione finale)
-```
+`Scouting -> Validation (opzionale) -> Discussion -> Incubation -> Analysis`
 
-### Percorso con repo dedicata (eccezione)
+### 2. Percorso prioritario (HVD / gap forti)
 
-```text
-Discussion
-  -> issue
-  -> dataset-incubator (contratto tecnico)
-  -> analisi/ (layer pubblico)
-  -> repo dedicata (solo se giustificata dai segnali sopra)
-```
+`Scouting -> Discussion -> Incubation -> Analysis -> Promotion`
 
-## Checklist sintetica
+---
 
-### Per entrare in dataset-incubator
-- domanda abbastanza chiara
-- fonte reale individuata
-- primo perimetro tecnico plausibile
-- issue operativa aperta
+## Note operative
 
-### Per entrare in analisi
-- domanda leggibile
-- Discussion collegata
-- primo output minimo definito
-- notebook o mart che raccontano qualcosa
-- decisione esplicita di rendere pubblico il filone
-
-### Per aprire una repo dedicata
-- contratto tecnico stabile almeno sul perimetro iniziale
-- output minimo gia' riuscito
-- backlog successivo piccolo ma reale
-- segnali concreti che giustificano governance propria
-
-## Repo coinvolte
-
-- `dataciviclab`: hub pubblico, Discussions, issue, `analisi/`, `projects/`
-- `dataset-incubator`: contratto tecnico permanente dei filoni
-- `project-template`: bootstrap delle repo dedicate
-- `toolkit`: motore tecnico e workflow canonico dei dati
-
-## Nota finale
-
-Il flusso non e' una catena rigida.
-Serve a mantenere il Lab leggibile, a ridurre il backlog vago e a promuovere solo i filoni che hanno davvero motivo di crescere.
+- **Anti-rumore**: non postare sui social per ogni aggiornamento tecnico.
+- **Issue madre**: usa `dataset-funnel.yml` in `dataciviclab` per tracciare la journey end-to-end nella Open Board.
+- **Chiusura**: una journey si chiude quando l'obiettivo del funnel viene raggiunto (`Analysis` o `Promotion`).

--- a/docs/local-setup.md
+++ b/docs/local-setup.md
@@ -36,23 +36,27 @@ dataciviclab-workspace/
 
 Dalla root del workspace:
 
-```bash
+```powershell
 python -m venv .venv
 ```
 
-Su Windows puoi usare anche `py -m venv .venv`.
+Su Windows puoi usare anche:
+
+```powershell
+py -m venv .venv
+```
 
 Poi attivalo.
 
 Su PowerShell:
 
-```bash
+```powershell
 .venv\Scripts\Activate.ps1
 ```
 
 Controllo rapido:
 
-```bash
+```powershell
 python -c "import sys; print(sys.executable)"
 ```
 
@@ -62,15 +66,16 @@ Il path deve puntare alla `.venv` del workspace.
 
 Vai nella repo `toolkit`:
 
-```bash
-cd toolkit
+```powershell
+Set-Location toolkit
 python -m pip install -e .
 ```
 
 Verifica minima:
 
-```bash
-toolkit --help
+```powershell
+Set-Location toolkit
+python -m toolkit.cli.app --help
 ```
 
 Se questo comando non parte, fermati qui e sistema prima l'ambiente.
@@ -84,20 +89,21 @@ Se usi VS Code, apri:
 Ti aiuta a:
 
 - vedere insieme le repo principali
-- usare più facilmente il Python locale giusto
+- usare piu' facilmente il Python locale giusto
 - navigare meglio tra repo diverse
 
 ## Primo comando reale
 
-Lo standard del Lab è usare il `dataset.yml` del candidate o del support dataset.
+Lo standard del Lab e' usare il `dataset.yml` del candidate o del support dataset.
 
 Esempio:
 
-```bash
-toolkit run all --config ../dataset-incubator/candidates/irpef-comunale/dataset.yml
+```powershell
+Set-Location toolkit
+python -m toolkit.cli.app run all --config ..\dataset-incubator\candidates\irpef-comunale\dataset.yml
 ```
 
-Questo è il primo test utile:
+Questo e' il primo test utile:
 
 - verifica che il toolkit parta
 - verifica che i path tra repo siano coerenti
@@ -105,7 +111,7 @@ Questo è il primo test utile:
 
 ## Dove vanno gli output
 
-Lo standard del Lab è:
+Lo standard del Lab e':
 
 - ogni repo viva ha il proprio `out/`
 - gli output runtime non stanno nel root del workspace
@@ -140,10 +146,10 @@ Qui vive la CLI e il motore di pipeline.
 
 ## Checklist finale
 
-Se tutto è a posto, dovresti riuscire a:
+Se tutto e' a posto, dovresti riuscire a:
 
 1. vedere le repo principali nel workspace locale
-2. usare la `.venv` del workspace
-3. lanciare `toolkit --help`
+2. usare una venv locale coerente
+3. lanciare `python -m toolkit.cli.app --help`
 4. eseguire almeno un `run all --config ...`
 5. trovare gli output nella cartella `out/` della repo giusta


### PR DESCRIPTION
## Summary
Allinea il funnel dataset e la documentazione di setup al modello operativo corrente del Lab.

## Changes
- aggiunge il template `dataset-funnel.yml` per la Issue Madre end-to-end
- riallinea `docs/dataset-project-flow.md` al funnel `SCOUTING -> VALIDATION -> CONSOLIDATION -> INCUBATION -> ANALYSIS -> PROMOTION`
- aggiorna `docs/local-setup.md` con esempi coerenti con PowerShell e `python -m toolkit.cli.app`

## Notes
- scope solo docs/template
- nessuna modifica runtime o pipeline
- utile anche durante il blocco merge sui repo tecnici