### PR TITLE
docs: add public workflow hub

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,9 @@ Questa guida vale per la repo `dataciviclab`.
 Per la guida completa su come contribuire al Lab (percorsi, ruoli, flusso di lavoro),
 vedi [docs/come-contribuire.md](docs/come-contribuire.md).
 
+Per i workflow pubblici cross-repo del Lab, vedi anche
+[docs/workflows.md](docs/workflows.md).
+
 Per le regole GitHub condivise dell'organizzazione, vedi
 [`.github`](https://github.com/dataciviclab/.github).
 
@@ -39,3 +42,4 @@ Apri una issue in `dataciviclab` se il lavoro riguarda:
 - tieni il cambiamento piccolo e leggibile
 - spiega il perché, non solo il cosa
 - se tocchi il flusso tra repo, controlla [docs/dataset-project-flow.md](docs/dataset-project-flow.md)
+- se il tuo cambiamento riguarda il passaggio tra repo, controlla anche [docs/workflows.md](docs/workflows.md)

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ domanda civica -> dati pubblici -> metodo chiaro -> output pubblico
 ```
 
 Il percorso completo, dal scouting di un dataset alla pubblicazione, è in [docs/dataset-project-flow.md](docs/dataset-project-flow.md).
+I workflow pubblici cross-repo del Lab sono raccolti in [docs/workflows.md](docs/workflows.md).
 
 Il principio resta lo stesso in ogni progetto:
 
@@ -51,5 +52,6 @@ Il principio resta lo stesso in ogni progetto:
 ## Per chi vuole contribuire attivamente
 
 - [docs/come-contribuire.md](docs/come-contribuire.md) — ruoli, flusso di lavoro, come entrare nel Lab
+- [docs/workflows.md](docs/workflows.md) — hub dei workflow pubblici tra le repo del Lab
 - [docs/repository-map.md](docs/repository-map.md) — mappa delle repo e cosa fa ognuna
 - [docs/governance-model.md](docs/governance-model.md) — come funzionano le decisioni

--- a/docs/come-contribuire.md
+++ b/docs/come-contribuire.md
@@ -17,6 +17,7 @@ se la conosci, la fonte pubblica di riferimento.
 
 Quando una Discussion matura e diventa lavoro concreto, si apre una issue nella repo giusta.
 Il flusso completo è in [dataset-project-flow.md](dataset-project-flow.md).
+Per i workflow pubblici nelle repo giuste, vedi anche [workflows.md](workflows.md).
 
 ## Vuoi contribuire a un lavoro in corso
 

--- a/docs/dataset-project-flow.md
+++ b/docs/dataset-project-flow.md
@@ -24,10 +24,14 @@ Il percorso non e' una catena rigida, ma un funnel di selezione: non tutti i seg
 
 ---
 
-## Step 1: SCOUTING (source-check)
+## Step 1: SCOUTING
 
 Si parte da una fonte o da un tema. Lo scouting tecnico serve ad assegnare un **verdict**.
-**Skill: `source-check`**
+**Workflow pubblico: `source-check`**
+
+Repo:
+
+- `source-observatory`
 
 Obiettivo: decidere se la fonte regge davvero su accesso, formato, domanda civica e rischio semantico.
 
@@ -51,14 +55,18 @@ Nota: questo step e' opzionale, non obbligatorio per ogni dataset.
 ## Step 3: CONSOLIDATION (GitHub Discussion)
 
 Se il segnale e' positivo, oppure se il caso e' gia' abbastanza forte da consolidare direttamente, fissiamo tutto in una Discussion in `dataciviclab`.
-**Skill: `open-discussion`**
+**Workflow del Lab: `open-discussion`**
 
 Qui la domanda si fissa, le fonti si ordinano e il filone diventa un artifact pubblico condivisibile. Non e' il posto per chiedere "interessa?", ma per dire "ecco perche' questa pista merita attenzione".
 
 ## Step 4: INCUBATION (dataset-incubator)
 
 Quando il perimetro v0 e' chiaro, il dataset entra formalmente in incubazione tecnica.
-**Skill: `intake-candidate`**
+**Workflow pubblico: `intake-candidate`**
+
+Repo:
+
+- `dataset-incubator`
 
 Qui si lavora su:
 
@@ -69,17 +77,21 @@ Qui si lavora su:
 
 Output atteso: candidate o PR verde che garantisce la stabilita' tecnica del dato.
 
+Per il run tecnico vero e proprio del candidate:
+
+- `dataset-incubator/workflows/run-candidate.md`
+
 ## Step 5: ANALYSIS (analisi/findings)
 
 Il layer pubblico finale vive in `dataciviclab/analisi/<slug>/`.
-**Skill: `promote-analisi`**
+**Workflow del Lab: `promote-analisi`**
 
 Un filone entra in `analisi/` se il dato tecnico e' stabile e vogliamo pubblicare una lettura leggibile (README, notebook o finding). Per molti dataset, questo e' l'endpoint naturale del funnel.
 
 ## Step 6: PROMOTION (data-explorer)
 
 Promozione al catalogo pubblico nazionale (`data-explorer`).
-**Skill: `add-to-explorer`**
+**Workflow del Lab: `add-to-explorer`**
 
 Questo step e' opzionale: ha senso soprattutto se il dataset e' periodico, ha una domanda civica larga o e' un gap prioritario che merita una vista pubblica permanente.
 
@@ -102,3 +114,7 @@ Questo step e' opzionale: ha senso soprattutto se il dataset e' periodico, ha un
 - **Anti-rumore**: non postare sui social per ogni aggiornamento tecnico.
 - **Issue madre**: usa `dataset-funnel.yml` in `dataciviclab` per tracciare la journey end-to-end nella Open Board.
 - **Chiusura**: una journey si chiude quando l'obiettivo del funnel viene raggiunto (`Analysis` o `Promotion`).
+
+Per i puntatori ai workflow pubblici nelle repo del Lab:
+
+- [workflows.md](workflows.md)

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -29,6 +29,10 @@ Dentro `dataciviclab` ci sono due livelli utili:
 - `analisi/` layer pubblico dei filoni attivi: README civico, notebook, Discussion collegata
 - `projects/` schede leggere dei filoni promossi a repo dedicate
 
+Per orientarti tra i workflow pubblici cross-repo del Lab:
+
+- [workflows.md](workflows.md)
+
 ## `.github`
 
 È la repo delle regole comuni su GitHub.
@@ -89,6 +93,38 @@ Qui stanno:
 Qui non stanno:
 - output pubblici o notebook definitivi come standard
 - filoni già promossi a analisi o repo dedicata
+
+Workflow pubblici principali:
+
+- `intake-candidate`
+- `run-candidate`
+
+Vedi:
+
+- `../../dataset-incubator/workflows/README.md`
+
+## `source-observatory`
+
+È il layer pubblico di scouting e osservazione delle fonti.
+
+Qui stanno:
+- workflow di scouting della fonte
+- radar di salute di poche fonti strategiche
+- segnali `catalog-watch`
+- monitoraggio ristretto di poche resource Tier 1
+
+Qui non stanno:
+- intake tecnico dei candidate
+- pipeline dataset
+- governance del Lab
+
+Workflow pubblico principale:
+
+- `source-check`
+
+Vedi:
+
+- `../../source-observatory/workflows/README.md`
 
 ## Repo dataset
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,0 +1,69 @@
+# Workflow pubblici del Lab
+
+Questa pagina fa da hub dei workflow pubblici cross-repo di DataCivicLab.
+
+Non spiega tutta la logica interna del core team. Serve soprattutto a chiarire:
+
+- da dove si entra
+- qual e' il passo successivo
+- in quale repo si lavora davvero
+
+## Mappa rapida
+
+### 1. Fonte -> Discussion
+
+Se parti da una fonte o da un dataset da verificare, il workflow pubblico di riferimento e':
+
+- [`source-observatory/workflows/source-check.md`](https://github.com/dataciviclab/source-observatory/blob/main/workflows/source-check.md)
+
+Questo e' il passaggio giusto quando devi capire se una fonte regge davvero
+come pista del Lab.
+
+Output tipici:
+
+- `go Discussion`
+- `watchlist`
+- `support dataset`
+- `aggiorna artefatto esistente`
+- `no-go`
+
+### 2. Discussion -> Candidate
+
+Quando una discussion o una fonte sono abbastanza mature per entrare in
+incubazione tecnica, il workflow pubblico di riferimento e':
+
+- [`dataset-incubator/workflows/intake-candidate.md`](https://github.com/dataciviclab/dataset-incubator/blob/main/workflows/intake-candidate.md)
+
+Questo e' il passaggio giusto quando vuoi trasformare un caso promettente in un
+candidate tecnico credibile.
+
+### 3. Candidate -> Run
+
+Quando un candidate esiste gia' e vuoi farlo girare davvero per vedere i dati,
+il workflow pubblico di riferimento e':
+
+- [`dataset-incubator/workflows/run-candidate.md`](https://github.com/dataciviclab/dataset-incubator/blob/main/workflows/run-candidate.md)
+
+Questo e' il passaggio giusto quando vuoi eseguire il candidate end-to-end,
+leggere gli output e distinguere tra run riuscito e blocco tecnico reale.
+
+## Ruolo delle repo
+
+- `dataciviclab`
+  - hub pubblico del funnel, Discussions, analisi, orientamento
+- `source-observatory`
+  - workflow di scouting e osservazione delle fonti
+- `dataset-incubator`
+  - intake tecnico, candidate, run e contratto tecnico permanente
+- `toolkit`
+  - motore tecnico e guide di uso del runtime, non funnel del Lab
+
+## Regola pratica
+
+- workflow ricorrente di scouting -> `source-observatory`
+- workflow ricorrente di intake e run -> `dataset-incubator`
+- `dataciviclab` racconta il funnel e rimanda alla repo giusta
+
+Se vuoi il quadro generale del funnel:
+
+- [dataset-project-flow.md](dataset-project-flow.md)


### PR DESCRIPTION
## Cosa cambia
- aggiunge `docs/workflows.md` come hub pubblico dei workflow cross-repo del Lab
- collega il nuovo hub da `README.md`, `CONTRIBUTING.md`, `docs/come-contribuire.md`, `docs/dataset-project-flow.md` e `docs/repository-map.md`
- riallinea il linguaggio pubblico da `Skill` a `Workflow` dove serve

## Perché
`dataciviclab` non deve duplicare i workflow delle altre repo, ma deve funzionare come hub del funnel: punto di ingresso, orientamento pubblico e mappa dei passaggi cross-repo.

## Come verificare
- leggere `docs/workflows.md`
- verificare i link dal `README.md` e da `docs/come-contribuire.md`
- verificare in `docs/dataset-project-flow.md` e `docs/repository-map.md` che i passaggi rimandino alle repo giuste

## Rischi residui
- l'hub dipende da link cross-repo, quindi eventuali rinomini futuri andranno riallineati qui
- il registro dei workflow pubblici potra' crescere in seguito, ma la v0 resta volutamente stretta

Closes #162