### PR TITLE
feat: automazione discussion → intake issue in dataset-incubator

### DIFF
--- a/.github/workflows/discussion-to-intake.yml
+++ b/.github/workflows/discussion-to-intake.yml
@@ -73,8 +73,31 @@ jobs:
           ${NOTES}
           EOF
 
+      - name: Check for existing intake issue (idempotency guard)
+        id: idempotency_check
+        env:
+          GH_TOKEN: ${{ secrets.LAB_OPS_TOKEN }}
+          DISCUSSION_URL: ${{ github.event.discussion.html_url }}
+          REPO: dataciviclab/dataset-incubator
+        run: |
+          EXISTING=$(gh issue list \
+            --repo "$REPO" \
+            --label "intake" \
+            --state open \
+            --search "$DISCUSSION_URL" \
+            --json url \
+            --jq '.[0].url // ""')
+          if [ -n "$EXISTING" ]; then
+            echo "Issue di intake già esistente per questa discussion: $EXISTING — skip."
+            echo "ISSUE_URL=$EXISTING" >> $GITHUB_ENV
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Create Issue in dataset-incubator
         id: create_issue
+        if: steps.idempotency_check.outputs.skip == 'false'
         env:
           GH_TOKEN: ${{ secrets.LAB_OPS_TOKEN }}
           TITLE: "intake: ${{ github.event.discussion.title }}"

--- a/.github/workflows/discussion-to-intake.yml
+++ b/.github/workflows/discussion-to-intake.yml
@@ -1,0 +1,74 @@
+name: Discussion to Intake Issue
+
+on:
+  discussion:
+    types: [labeled]
+
+jobs:
+  create-intake-issue:
+    if: github.event.label.name == 'intake' && github.event.discussion.category.name == 'Datasets'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Parse Discussion Body
+        id: parse
+        env:
+          DISCUSSION_BODY: ${{ github.event.discussion.body }}
+        run: |
+          # Run the parsing script and capture JSON output
+          JSON_DATA=$(python scripts/parse_discussion.py)
+          echo "PARSED_DATA=$JSON_DATA" >> $GITHUB_ENV
+          
+          # Debug output (optional)
+          echo "Extracted fields: $JSON_DATA"
+
+      - name: Create Issue in dataset-incubator
+        env:
+          GH_TOKEN: ${{ secrets.LAB_OPS_TOKEN || secrets.GITHUB_TOKEN }}
+          TITLE: "intake: ${{ github.event.discussion.title }}"
+          REPO: "dataciviclab/dataset-incubator"
+          URL: "${{ github.event.discussion.html_url }}"
+          AUTHOR: "${{ github.event.discussion.user.login }}"
+        run: |
+          # Extract fields from environment JSON
+          SOURCE=$(echo $PARSED_DATA | jq -r '.source // "N/D"')
+          QUESTION=$(echo $PARSED_DATA | jq -r '(.question // "") + "\n\n(Dettagli estratti da Discussion: " + env.URL + " proposta da @" + env.AUTHOR + ")"')
+          WHY_NOW=$(echo $PARSED_DATA | jq -r '.why_now // "N/D"')
+          SCOPE=$(echo $PARSED_DATA | jq -r '.scope // "N/D"')
+          NOTES=$(echo $PARSED_DATA | jq -r '.notes // ""')
+
+          # Create the issue using GitHub CLI
+          # Note: We use the 'intake' label and map to the body of the new-candidate template
+          gh issue create --repo $REPO \
+            --title "$TITLE" \
+            --label "intake" \
+            --body "### Tipo di intake
+          candidate
+          
+          ### Domanda guida o uso previsto
+          $QUESTION
+          
+          ### Fonte principale
+          $SOURCE
+          
+          ### Perimetro iniziale
+          $SCOPE
+          
+          ### Perché vale la pena incubarlo
+          $WHY_NOW
+          
+          ### Output minimo atteso
+          Mart minimo v0 (Automatico)
+          
+          ### Prossimo passo operativo
+          Validazione fonte e creazione primo dataset.yml
+          
+          ### Note o rischi noti
+          $NOTES"

--- a/.github/workflows/discussion-to-intake.yml
+++ b/.github/workflows/discussion-to-intake.yml
@@ -1,5 +1,11 @@
 name: Discussion to Intake Issue
 
+# Triggered when a discussion in the Datasets category receives the 'intake' label.
+# Creates an intake issue in dataset-incubator and posts a confirmation comment.
+#
+# Required secret: LAB_OPS_TOKEN — a PAT with repo scope on dataciviclab/dataset-incubator.
+# GITHUB_TOKEN alone is not sufficient (cross-repo issue creation requires explicit access).
+
 on:
   discussion:
     types: [labeled]
@@ -8,6 +14,9 @@ jobs:
   create-intake-issue:
     if: github.event.label.name == 'intake' && github.event.discussion.category.name == 'Datasets'
     runs-on: ubuntu-latest
+    permissions:
+      discussions: write
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -15,60 +24,81 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Parse Discussion Body
-        id: parse
         env:
           DISCUSSION_BODY: ${{ github.event.discussion.body }}
         run: |
-          # Run the parsing script and capture JSON output
           JSON_DATA=$(python scripts/parse_discussion.py)
           echo "PARSED_DATA=$JSON_DATA" >> $GITHUB_ENV
-          
-          # Debug output (optional)
           echo "Extracted fields: $JSON_DATA"
 
-      - name: Create Issue in dataset-incubator
+      - name: Build issue body
         env:
-          GH_TOKEN: ${{ secrets.LAB_OPS_TOKEN || secrets.GITHUB_TOKEN }}
-          TITLE: "intake: ${{ github.event.discussion.title }}"
-          REPO: "dataciviclab/dataset-incubator"
-          URL: "${{ github.event.discussion.html_url }}"
-          AUTHOR: "${{ github.event.discussion.user.login }}"
+          URL: ${{ github.event.discussion.html_url }}
+          AUTHOR: ${{ github.event.discussion.user.login }}
         run: |
-          # Extract fields from environment JSON
-          SOURCE=$(echo $PARSED_DATA | jq -r '.source // "N/D"')
-          QUESTION=$(echo $PARSED_DATA | jq -r '(.question // "") + "\n\n(Dettagli estratti da Discussion: " + env.URL + " proposta da @" + env.AUTHOR + ")"')
-          WHY_NOW=$(echo $PARSED_DATA | jq -r '.why_now // "N/D"')
-          SCOPE=$(echo $PARSED_DATA | jq -r '.scope // "N/D"')
-          NOTES=$(echo $PARSED_DATA | jq -r '.notes // ""')
+          SOURCE=$(echo "$PARSED_DATA" | jq -r '.source // "N/D"')
+          QUESTION=$(echo "$PARSED_DATA" | jq -r '.question // "N/D"')
+          WHY_NOW=$(echo "$PARSED_DATA" | jq -r '.why_now // "N/D"')
+          SCOPE=$(echo "$PARSED_DATA" | jq -r '.scope // "N/D"')
+          NOTES=$(echo "$PARSED_DATA" | jq -r '.notes // ""')
 
-          # Create the issue using GitHub CLI
-          # Note: We use the 'intake' label and map to the body of the new-candidate template
-          gh issue create --repo $REPO \
-            --title "$TITLE" \
-            --label "intake" \
-            --body "### Tipo di intake
+          cat > issue_body.md << EOF
+          ### Tipo di intake
           candidate
-          
+
           ### Domanda guida o uso previsto
-          $QUESTION
-          
+          ${QUESTION}
+
+          (Estratto da Discussion: ${URL} — proposta da @${AUTHOR})
+
           ### Fonte principale
-          $SOURCE
-          
+          ${SOURCE}
+
           ### Perimetro iniziale
-          $SCOPE
-          
+          ${SCOPE}
+
           ### Perché vale la pena incubarlo
-          $WHY_NOW
-          
+          ${WHY_NOW}
+
           ### Output minimo atteso
-          Mart minimo v0 (Automatico)
-          
+          Mart minimo v0
+
           ### Prossimo passo operativo
           Validazione fonte e creazione primo dataset.yml
-          
+
           ### Note o rischi noti
-          $NOTES"
+          ${NOTES}
+          EOF
+
+      - name: Create Issue in dataset-incubator
+        id: create_issue
+        env:
+          GH_TOKEN: ${{ secrets.LAB_OPS_TOKEN }}
+          TITLE: "intake: ${{ github.event.discussion.title }}"
+          REPO: dataciviclab/dataset-incubator
+        run: |
+          ISSUE_URL=$(gh issue create \
+            --repo "$REPO" \
+            --title "$TITLE" \
+            --label "intake" \
+            --body-file issue_body.md)
+          echo "ISSUE_URL=$ISSUE_URL" >> $GITHUB_ENV
+
+      - name: Comment on Discussion
+        env:
+          GH_TOKEN: ${{ secrets.LAB_OPS_TOKEN }}
+          DISCUSSION_ID: ${{ github.event.discussion.node_id }}
+        run: |
+          gh api graphql \
+            -f query='mutation($discussionId: ID!, $body: String!) {
+              addDiscussionComment(input: {discussionId: $discussionId, body: $body}) {
+                comment { id }
+              }
+            }' \
+            -f discussionId="$DISCUSSION_ID" \
+            -f body="Issue di intake aperta in dataset-incubator: $ISSUE_URL
+
+          I campi sono stati estratti automaticamente dal corpo della discussion. Verificare che siano corretti prima di procedere con l'incubazione."

--- a/scripts/parse_discussion.py
+++ b/scripts/parse_discussion.py
@@ -63,6 +63,9 @@ def map_fields(parsed):
     return result
 
 
+REQUIRED_FIELDS = ("question", "source")
+
+
 def main():
     body = os.environ.get("DISCUSSION_BODY", "")
     if not body:
@@ -71,6 +74,15 @@ def main():
 
     parsed = parse_discussion_body(body)
     result = map_fields(parsed)
+
+    missing = [f for f in REQUIRED_FIELDS if not result.get(f)]
+    if missing:
+        print(
+            f"ERROR: campi obbligatori mancanti o non riconosciuti: {', '.join(missing)}. "
+            "Verificare che il template della discussion sia compilato correttamente.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     # Output as JSON for GitHub Actions
     print(json.dumps(result))

--- a/scripts/parse_discussion.py
+++ b/scripts/parse_discussion.py
@@ -3,10 +3,11 @@ import re
 import sys
 import json
 
+
 def parse_discussion_body(body):
     """
-    Parses a GitHub Discussion body (YAML form output) to extract field values.
-    Headings are formatted as '### Label'.
+    Parses a GitHub Discussion body (markdown with ### headings) to extract field values.
+    Matching is case-insensitive and strips punctuation to tolerate minor template drift.
     """
     fields = {}
     current_label = None
@@ -22,35 +23,58 @@ def parse_discussion_body(body):
             current_content = []
         elif current_label:
             current_content.append(line)
-    
+
     if current_label:
         fields[current_label] = "\n".join(current_content).strip()
-    
+
     return fields
+
+
+def _normalize(text):
+    """Lowercase + strip punctuation for fuzzy heading match."""
+    return re.sub(r'[^\w\s]', '', text).lower().strip()
+
+
+# Mapping: normalized heading fragment -> issue field key
+# Using fragments so minor wording changes (accents, punctuation) don't break the match.
+_FRAGMENT_MAP = {
+    "fonte": "source",
+    "domanda civica": "question",
+    "perch": "why_now",        # covers "Perché è rilevante?" and variants
+    "copertura": "scope",
+    "granularit": "scope",     # fallback if heading splits differently
+    "limiti": "notes",
+    "rischi": "notes",
+    "cosa contiene": "description",
+}
+
+
+def map_fields(parsed):
+    result = {}
+    for heading, value in parsed.items():
+        norm = _normalize(heading)
+        matched_key = None
+        for fragment, key in _FRAGMENT_MAP.items():
+            if fragment in norm:
+                matched_key = key
+                break
+        if matched_key and matched_key not in result:
+            result[matched_key] = value
+    return result
+
 
 def main():
     body = os.environ.get("DISCUSSION_BODY", "")
     if not body:
-        print("ERROR: DISCUSSION_BODY environment variable is empty.")
+        print("ERROR: DISCUSSION_BODY environment variable is empty.", file=sys.stderr)
         sys.exit(1)
 
     parsed = parse_discussion_body(body)
-    
-    # Mapping to dataset-incubator issue template
-    # Discussion Label -> Issue Field
-    mapping = {
-        "Fonte ufficiale": "source",
-        "Domanda civica possibile": "question",
-        "Perché è rilevante?": "why_now",
-        "Copertura e granularità": "scope",
-        "Limiti o rischi noti": "notes",
-        "Cosa contiene?": "description"
-    }
+    result = map_fields(parsed)
 
-    result = {mapping.get(k, k): v for k, v in parsed.items()}
-    
     # Output as JSON for GitHub Actions
     print(json.dumps(result))
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/parse_discussion.py
+++ b/scripts/parse_discussion.py
@@ -1,0 +1,56 @@
+import os
+import re
+import sys
+import json
+
+def parse_discussion_body(body):
+    """
+    Parses a GitHub Discussion body (YAML form output) to extract field values.
+    Headings are formatted as '### Label'.
+    """
+    fields = {}
+    current_label = None
+    current_content = []
+
+    lines = body.splitlines()
+    for line in lines:
+        match = re.match(r'^###\s+(.*)', line)
+        if match:
+            if current_label:
+                fields[current_label] = "\n".join(current_content).strip()
+            current_label = match.group(1).strip()
+            current_content = []
+        elif current_label:
+            current_content.append(line)
+    
+    if current_label:
+        fields[current_label] = "\n".join(current_content).strip()
+    
+    return fields
+
+def main():
+    body = os.environ.get("DISCUSSION_BODY", "")
+    if not body:
+        print("ERROR: DISCUSSION_BODY environment variable is empty.")
+        sys.exit(1)
+
+    parsed = parse_discussion_body(body)
+    
+    # Mapping to dataset-incubator issue template
+    # Discussion Label -> Issue Field
+    mapping = {
+        "Fonte ufficiale": "source",
+        "Domanda civica possibile": "question",
+        "Perché è rilevante?": "why_now",
+        "Copertura e granularità": "scope",
+        "Limiti o rischi noti": "notes",
+        "Cosa contiene?": "description"
+    }
+
+    result = {mapping.get(k, k): v for k, v in parsed.items()}
+    
+    # Output as JSON for GitHub Actions
+    print(json.dumps(result))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Aggiunge un workflow che automatizza il passaggio discussion → issue di intake in `dataset-incubator`.

**Trigger**: label `intake` applicata a una discussion in categoria `Datasets`

**Flusso**:
1. Parsa il body della discussion (heading `### ...`) estraendo i campi chiave (fonte, domanda civica, perimetro, perché, note)
2. Crea un issue in `dataciviclab/dataset-incubator` con label `intake`, body mappato al template `new-candidate`
3. Posta un commento di conferma sulla discussion con link all'issue aperta

## Note tecniche

- Richiede secret `LAB_OPS_TOKEN` (PAT con scope `repo` su `dataset-incubator`) — `GITHUB_TOKEN` non è sufficiente per la creazione cross-repo
- Il parser usa matching fuzzy sugli heading (normalizzazione lowercase + strip punteggiatura) per tollerare variazioni minori nel template della discussion
- Il body dell'issue viene scritto su file temporaneo (`--body-file`) per evitare conflitti YAML con gli heading `###`

## Test plan

- [ ] Applicare label `intake` a una discussion di test in categoria `Datasets`
- [ ] Verificare che venga creato l'issue in DI con i campi corretti
- [ ] Verificare che compaia il commento di conferma sulla discussion

🤖 Generated with [Claude Code](https://claude.com/claude-code)