### PR TITLE
fix: parse discussion h2 headings for intake workflow

### DIFF
--- a/scripts/parse_discussion.py
+++ b/scripts/parse_discussion.py
@@ -6,7 +6,7 @@ import json
 
 def parse_discussion_body(body):
     """
-    Parses a GitHub Discussion body (markdown with ### headings) to extract field values.
+    Parses a GitHub Discussion body (markdown with ##/### headings) to extract field values.
     Matching is case-insensitive and strips punctuation to tolerate minor template drift.
     """
     fields = {}
@@ -15,7 +15,7 @@ def parse_discussion_body(body):
 
     lines = body.splitlines()
     for line in lines:
-        match = re.match(r'^###\s+(.*)', line)
+        match = re.match(r'^#{2,3}\s+(.*)', line)
         if match:
             if current_label:
                 fields[current_label] = "\n".join(current_content).strip()

--- a/scripts/test_parse_discussion.py
+++ b/scripts/test_parse_discussion.py
@@ -1,0 +1,49 @@
+import unittest
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from parse_discussion import map_fields, parse_discussion_body
+
+
+class ParseDiscussionTest(unittest.TestCase):
+    def test_parses_h2_discussion_template(self):
+        body = """## Fonte ufficiale
+
+ISTAT SDMX
+
+## Domanda civica
+
+Quale territorio ha il divario maggiore?
+
+## Copertura e granularita'
+
+Regioni, 2012-2022.
+"""
+
+        parsed = parse_discussion_body(body)
+        mapped = map_fields(parsed)
+
+        self.assertEqual(mapped["source"], "ISTAT SDMX")
+        self.assertEqual(mapped["question"], "Quale territorio ha il divario maggiore?")
+        self.assertEqual(mapped["scope"], "Regioni, 2012-2022.")
+
+    def test_still_parses_h3_discussion_template(self):
+        body = """### Fonte
+
+Portale demo
+
+### Domanda civica
+
+Che cosa cambia?
+"""
+
+        parsed = parse_discussion_body(body)
+        mapped = map_fields(parsed)
+
+        self.assertEqual(mapped["source"], "Portale demo")
+        self.assertEqual(mapped["question"], "Che cosa cambia?")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixa il parser usato dal workflow `Discussion to Intake Issue` quando una discussion usa heading Markdown `##` invece di `###`.

Il run fallito dopo il merge di #219 si ferma nello step `Parse Discussion Body` perche' il parser riconosceva solo `### ...`, mentre la discussion labelata usa heading `## Fonte ufficiale`, `## Domanda civica`, ecc.

Run fallito: https://github.com/dataciviclab/dataciviclab/actions/runs/24530037601

## Cosa cambia

- `scripts/parse_discussion.py` accetta heading `##` e `###`.
- Aggiunge test stdlib `unittest` per template `##` e regressione `###`.

## Test

```bash
python3 -m py_compile scripts/parse_discussion.py scripts/test_parse_discussion.py
python3 -m unittest scripts/test_parse_discussion.py
```

## Dopo merge

Togliere e riapplicare la label `intake` alla discussion per retriggerare il workflow.