### PR TITLE
fix: compact intake issue body and fix UTF-8 encoding

### DIFF
--- a/.github/workflows/discussion-to-intake.yml
+++ b/.github/workflows/discussion-to-intake.yml
@@ -76,6 +76,15 @@ jobs:
               "",
               "### Note o rischi noti",
               field("notes", ""),
+              "",
+              "---",
+              "## Passi operativi",
+              "",
+              "Seguire il workflow canonico di intake:",
+              "",
+              "1. **Scaffolding candidate** — creare `candidates/{slug}/` con `dataset.yml`, `README.md`, `notes.md`, `sql/clean.sql`, `sql/mart.sql`, notebook v0",
+              "2. **Run pipeline** — `toolkit run all --config candidates/{slug}/dataset.yml`",
+              "3. **Review e PR** — verificare Definition of Done in [`workflows/intake-candidate.md`](../blob/main/workflows/intake-candidate.md), aprire PR con label `intake`",
           ]
 
           with open("issue_body.md", "w", encoding="utf-8") as f:

--- a/.github/workflows/discussion-to-intake.yml
+++ b/.github/workflows/discussion-to-intake.yml
@@ -39,39 +39,48 @@ jobs:
           URL: ${{ github.event.discussion.html_url }}
           AUTHOR: ${{ github.event.discussion.user.login }}
         run: |
-          SOURCE=$(echo "$PARSED_DATA" | jq -r '.source // "N/D"')
-          QUESTION=$(echo "$PARSED_DATA" | jq -r '.question // "N/D"')
-          WHY_NOW=$(echo "$PARSED_DATA" | jq -r '.why_now // "N/D"')
-          SCOPE=$(echo "$PARSED_DATA" | jq -r '.scope // "N/D"')
-          NOTES=$(echo "$PARSED_DATA" | jq -r '.notes // ""')
+          python - << 'PY'
+          import json, os, textwrap
 
-          cat > issue_body.md << EOF
-          ### Tipo di intake
-          candidate
+          data = json.loads(os.environ["PARSED_DATA"])
+          url = os.environ["URL"]
+          author = os.environ["AUTHOR"]
 
-          ### Domanda guida o uso previsto
-          ${QUESTION}
+          def field(key, fallback="N/D"):
+              return data.get(key) or fallback
 
-          (Estratto da Discussion: ${URL} — proposta da @${AUTHOR})
+          lines = [
+              "### Tipo di intake",
+              "candidate",
+              "",
+              "### Domanda guida o uso previsto",
+              field("question"),
+              "",
+              f"(Estratto da Discussion: {url} — proposta da @{author})",
+              "",
+              "### Fonte principale",
+              field("source"),
+              "",
+              "### Perimetro iniziale",
+              field("scope"),
+              "",
+              "### Perché vale la pena incubarlo",
+              field("why_now"),
+              f"→ contesto completo: {url}",
+              "",
+              "### Output minimo atteso",
+              "Mart minimo v0",
+              "",
+              "### Prossimo passo operativo",
+              "Validazione fonte e creazione primo dataset.yml",
+              "",
+              "### Note o rischi noti",
+              field("notes", ""),
+          ]
 
-          ### Fonte principale
-          ${SOURCE}
-
-          ### Perimetro iniziale
-          ${SCOPE}
-
-          ### Perché vale la pena incubarlo
-          ${WHY_NOW}
-
-          ### Output minimo atteso
-          Mart minimo v0
-
-          ### Prossimo passo operativo
-          Validazione fonte e creazione primo dataset.yml
-
-          ### Note o rischi noti
-          ${NOTES}
-          EOF
+          with open("issue_body.md", "w", encoding="utf-8") as f:
+              f.write("\n".join(lines) + "\n")
+          PY
 
       - name: Check for existing intake issue (idempotency guard)
         id: idempotency_check

--- a/scripts/parse_discussion.py
+++ b/scripts/parse_discussion.py
@@ -63,6 +63,56 @@ def map_fields(parsed):
     return result
 
 
+def _compact_text(text, max_lines):
+    """Keep first max_lines non-empty lines of a text block."""
+    lines = [l for l in text.splitlines() if l.strip()]
+    return "\n".join(lines[:max_lines])
+
+
+def _compact_bullets(text, max_bullets):
+    """Keep first max_bullets bullet lines; ignore narrative paragraphs after bullets end."""
+    bullets = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("-") or stripped.startswith("*"):
+            bullets.append(line)
+            if len(bullets) >= max_bullets:
+                break
+    # Fallback: if no bullets found, treat as plain text
+    if not bullets:
+        return _compact_text(text, max_bullets)
+    return "\n".join(bullets)
+
+
+# Per-field compact rules: (strategy, limit)
+_COMPACT_RULES = {
+    "question": ("text", 2),
+    "source":   ("bullets", 5),
+    "scope":    ("bullets", 5),
+    "why_now":  ("text", 3),
+    "notes":    ("bullets", 5),
+}
+
+
+def compact_fields(result):
+    """Apply per-field compaction rules to extracted fields."""
+    compacted = {}
+    for key, value in result.items():
+        if not value:
+            compacted[key] = value
+            continue
+        rule = _COMPACT_RULES.get(key)
+        if rule is None:
+            compacted[key] = value
+            continue
+        strategy, limit = rule
+        if strategy == "text":
+            compacted[key] = _compact_text(value, limit)
+        else:
+            compacted[key] = _compact_bullets(value, limit)
+    return compacted
+
+
 REQUIRED_FIELDS = ("question", "source")
 
 
@@ -84,8 +134,10 @@ def main():
         )
         sys.exit(1)
 
+    result = compact_fields(result)
+
     # Output as JSON for GitHub Actions
-    print(json.dumps(result))
+    print(json.dumps(result, ensure_ascii=False))
 
 
 if __name__ == "__main__":

--- a/scripts/test_parse_discussion.py
+++ b/scripts/test_parse_discussion.py
@@ -3,7 +3,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from parse_discussion import map_fields, parse_discussion_body
+from parse_discussion import map_fields, parse_discussion_body, compact_fields
 
 
 class ParseDiscussionTest(unittest.TestCase):
@@ -43,6 +43,28 @@ Che cosa cambia?
 
         self.assertEqual(mapped["source"], "Portale demo")
         self.assertEqual(mapped["question"], "Che cosa cambia?")
+
+
+    def test_compact_fields_truncates_bullets(self):
+        result = {
+            "source": "- A\n- B\n- C\n- D\n- E\n- F\n- G",
+            "question": "Domanda uno\nriga due\nriga tre extra",
+            "why_now": "Motivo 1\nMotivo 2\nMotivo 3\nMotivo 4",
+            "notes": "- N1\n- N2\n- N3\n- N4\n- N5\n- N6",
+            "scope": "- S1\n- S2\n- S3\n- S4\n- S5\n- S6",
+        }
+        compacted = compact_fields(result)
+        self.assertEqual(len(compacted["source"].splitlines()), 5)
+        self.assertEqual(len(compacted["question"].splitlines()), 2)
+        self.assertEqual(len(compacted["why_now"].splitlines()), 3)
+        self.assertEqual(len(compacted["notes"].splitlines()), 5)
+        self.assertEqual(len(compacted["scope"].splitlines()), 5)
+
+    def test_compact_fields_noop_when_short(self):
+        result = {"source": "- A\n- B", "question": "Domanda breve"}
+        compacted = compact_fields(result)
+        self.assertEqual(compacted["source"], "- A\n- B")
+        self.assertEqual(compacted["question"], "Domanda breve")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Aggiunta truncation per-field in `parse_discussion.py`: max 2 righe per domanda, 5 bullet per fonte/perimetro/note, 3 righe per why_now
- Body building migrato da bash heredoc a Python — risolve il bug di encoding UTF-8 (em dash e caratteri speciali venivano mangled via jq → bash, es. `â€"` invece di `—`)
- Aggiunto pointer `→ contesto completo: {url}` dopo `why_now`
- 2 nuovi test per `compact_fields`

Closes #221

## Test plan

- [ ] 4 test Python passano (`pytest scripts/test_parse_discussion.py`)
- [ ] Verificare sul prossimo intake reale che il body sia compatto e l'encoding corretto