### PR TITLE
Template analisi rinnovato + skills/new-analysis.md

### DIFF
--- a/analisi/_template/README.md
+++ b/analisi/_template/README.md
@@ -23,7 +23,10 @@ Introduzione al tema. Perché il problema è rilevante. Cosa cercano i dati.
 | 2020 |  |  |
 | 2023 |  |  |
 
-![Descrizione figura](figures/<slug>_<desc>.png)
+<!--
+  TODO: aggiungi figura salvata dal notebook in figures/.
+  Esempio: ![Trend nazionale](figures/nome_trend.png)
+-->
 
 Testo che commenta la tabella e la figura. Ogni **dato** deve essere verificabile dal notebook.
 

--- a/analisi/_template/README.md
+++ b/analisi/_template/README.md
@@ -1,43 +1,66 @@
-# Template Candidato Analisi
+---
+title: ""
+description: ""
+topics:
+status: active
+dataset_slug: ""
+---
 
-## Domanda principale
+# Titolo — sottotitolo
 
-Scrivi una domanda civica chiara in una frase.
+**Hook**: una o due frasi che catturano l'attenzione e dicono il risultato principale.
 
-## Perché conta
+> Numeri chiave in evidenza, se utili subito.
 
-- per chi è utile
-- quale decisione o comprensione può migliorare
+---
+
+## 1. Prima sezione narrativa
+
+Introduzione al tema. Perché il problema è rilevante. Cosa cercano i dati.
+
+| Anno | Metrica | Metrica |
+|------|---------|---------|
+| 2020 |  |  |
+| 2023 |  |  |
+
+![Descrizione figura](figures/<slug>_<desc>.png)
+
+Testo che commenta la tabella e la figura. Ogni **dato** deve essere verificabile dal notebook.
+
+## 2. Seconda sezione
+
+Altra dimensione dell'analisi. Tabella, figura, commento.
+
+## Cosa abbiamo imparato
+
+### I fatti
+
+1. **Primo risultato** — evidenza.
+2. **Secondo risultato** — evidenza.
+3. **Terzo risultato** — evidenza.
+
+### E allora?
+
+Domanda civica conclusiva. Non una risposta, ma una domanda che apre.
+
+---
 
 ## Dataset
 
-- fonte
-- copertura temporale
-- copertura territoriale
-- limiti noti
+- **Fonte**:
+- **Copertura temporale**:
+- **Dataset in clean-query**: `<slug>`
 
-## Output minimo atteso
+### Limiti
 
-Definisci un output piccolo ma pubblicabile:
+-
 
-- notebook con lettura v1 e finding principale
-- tabella sintetica commentata
+---
+
+## Notebook
+
+- `notebooks/<slug>_v2.ipynb` — validazione dati, genera figure in `figures/`
 
 ## Contratto tecnico
 
-Il contratto tecnico (dataset.yml, SQL, pipeline) vive in dataset-incubator:
 [candidates/<slug>](https://github.com/dataciviclab/dataset-incubator/tree/main/candidates/<slug>)
-
-## Discussion collegata
-
-- Discussion: [link]
-
-## Stato
-
-- `active` / `in valutazione` / `archiviato`
-
-## Decisione attesa al checkpoint
-
-- continuare in analisi/ (destinazione normale)
-- promuovere a repo dedicata (solo se giustificato)
-- archiviare

--- a/skills/new-analysis.md
+++ b/skills/new-analysis.md
@@ -1,0 +1,114 @@
+---
+name: new-analysis
+description: Workflow canonico per avviare e pubblicare una nuova analisi in `dataciviclab/analisi/`, dal setup del branch alla PR.
+metadata:
+  version: "1.0"
+  status: "stable"
+  standard: "compact-first"
+---
+
+# Skill: new-analysis
+
+Avvia e completa una nuova analisi in `dataciviclab/analisi/`.
+
+## Quando usarla
+
+- Un dataset è già pubblicato su GCS (passato da `dataset-incubator`)
+- Esiste una domanda civica chiara (Discussion o issue in `dataciviclab`)
+- Si vuole produrre README pubblico + notebook tecnico + figure
+
+## Prerequisiti
+
+- Python 3.12+ con duckdb, pandas, matplotlib, jupyter, nbconvert
+- Accesso in lettura a `gs://dataciviclab-clean/` (pubblico, nessun secret)
+- Branch fresh da `main`
+
+## Struttura finale del filone
+
+```
+analisi/<slug>/
+  README.md          # Pagina pubblica (storia + figure)
+  figures/           # PNG generati dal notebook
+  notebooks/
+    <slug>_v2.ipynb  # Notebook tecnico (codice + grafici)
+```
+
+## Step
+
+### 1. Setup
+
+```bash
+git checkout -b feat/<slug>
+mkdir -p analisi/<slug>/notebooks analisi/<slug>/figures
+```
+
+Copia lo scheletro del README da `analisi/_template/README.md`.
+
+### 2. Notebook tecnico
+
+Scrivi il notebook come strumento di validazione:
+
+- Prima cella: markdown con titolo, dataset, link al README
+- Setup DuckDB + GCS: `con.execute("INSTALL httpfs; LOAD httpfs;")`
+- Query di verifica copertura (anni, righe)
+- Una cella codice per ogni trend/domanda, con commento breve (`# 1. Trend nazionale`)
+- Ogni grafico:
+  ```python
+  plt.savefig('../figures/<slug>_<desc>.png', dpi=150, bbox_inches='tight')
+  ```
+- Nessuna narrativa estesa (sta nel README)
+- Nessuna conclusione (sta nel README)
+
+### 3. README pubblico
+
+Segui la struttura di `analisi/_template/README.md`:
+
+- Frontmatter YAML obbligatorio (title, description, topics, status, dataset_slug)
+- Hook iniziale (1-2 frasi con il risultato principale)
+- Sezioni con tabelle + figure intervallate da narrativa
+- Conclusione con domanda civica
+- Sezione Dataset + Limiti
+- Link al notebook e al contratto tecnico
+
+Il lettore tipo è un cittadino o policy maker — niente codice, niente dettagli implementativi.
+
+### 4. Figure
+
+- DPI: 150
+- Colori: palette semplice (`#2c3e50`, `#27ae60`, `#e74c3c`, `#95a5a6`)
+- `bbox_inches='tight'` per tagliare il bianco
+- Nomi file descrittivi: `<slug>_trend_nazionale.png`
+- Salvate in `figures/` e referenziate dal README come `![descrizione](figures/<nome>.png)`
+
+### 5. Verifica pre-PR
+
+Prima di aprire la PR:
+
+- [ ] Il notebook gira senza errori: `jupyter nbconvert --to notebook --execute notebooks/<slug>_v2.ipynb`
+- [ ] Le figure sono aggiornate e in figures/
+- [ ] I numeri nel README corrispondono al notebook
+- [ ] README linka correttamente le figure
+- [ ] Il frontmatter YAML è compilato
+
+### 6. PR
+
+```bash
+git add analisi/<slug>/
+git commit -m "<slug>: analisi con README, notebook, figure"
+git push origin feat/<slug>
+```
+
+Apri PR verso `main`. La CI esegue automaticamente il notebook e verifica che non ci siano errori.
+
+## Regole
+
+- README e notebook hanno ruoli distinti: non duplicare narrativa
+- Le figure sono l'unico ponte tra notebook e README
+- Non tracciare file generati dal notebook (es. `summary.json`) a meno di esigenze esplicite
+- Non includere riferimenti ad agenti, handoff o procedure interne nel README pubblico
+- I numeri nel README devono essere allineati al notebook eseguito
+
+## Limitazioni
+
+- Il notebook assume accesso pubblico a GCS — non funziona offline
+- Dataset con dati sensibili non vanno in analisi/ (solo dati aperti)


### PR DESCRIPTION
### Cosa cambia

- **analisi/_template/README.md** aggiornato agli standard attuali: frontmatter YAML, hook, sezioni con tabelle e figure, conclusione civica, dataset, limiti
- **analisi/_template/figures/** con .gitkeep
- **skills/new-analysis.md**: skill canonica pubblica per avviare una nuova analisi (setup, notebook, README, figure, CI, PR)

### Stessa architettura

Il template riflette la separazione README/notebook già applicata a dipendenti-pubblici e irpef-comunale.