### PR TITLE
fix: link relativi .md → path assoluti /docs/slug/ nei file docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
           for file in files:
               text = file.read_text(encoding="utf-8")
               for target in pattern.findall(text):
-                  if target.startswith(("http://", "https://", "mailto:", "#")):
+                  if target.startswith(("http://", "https://", "mailto:", "#", "/")):
                       continue
                   target_path = target.split("#", 1)[0]
                   if not target_path:

--- a/docs/come-contribuire.md
+++ b/docs/come-contribuire.md
@@ -20,8 +20,8 @@ Non serve saper programmare. Serve saper formulare bene la domanda e indicare,
 se la conosci, la fonte pubblica di riferimento.
 
 Quando una Discussion matura e diventa lavoro concreto, si apre una issue nella repo giusta.
-Il flusso completo è in [dataset-project-flow.md](dataset-project-flow.md).
-Per i workflow pubblici nelle repo giuste, vedi anche [workflows.md](workflows.md).
+Il flusso completo è in [dataset-project-flow](/docs/dataset-project-flow/).
+Per i workflow pubblici nelle repo giuste, vedi anche [workflows](/docs/workflows/).
 
 ## Vuoi contribuire a un lavoro in corso
 
@@ -52,7 +52,7 @@ Per contribuire a un progetto dataset:
 2. guarda le issue aperte nella repo dedicata
 3. se non c'è ancora una repo dedicata, parti dalla Discussion collegata
 
-Per il setup tecnico locale: [local-setup.md](local-setup.md).
+Per il setup tecnico locale: [local-setup](/docs/local-setup/).
 
 ## Come funzionano le decisioni
 
@@ -65,6 +65,6 @@ Il Lab è piccolo e le decisioni si prendono in modo trasparente su GitHub.
 La conversazione può partire ovunque — Discord, LinkedIn, in privato.
 La traccia utile deve restare su GitHub.
 
-Per capire come funziona la governance del Lab: [governance-model.md](governance-model.md).
+Per capire come funziona la governance del Lab: [governance-model](/docs/governance-model/).
 
 Per template issue, PR e codice di condotta validi su tutte le repo: [`.github`](https://github.com/dataciviclab/.github).

--- a/docs/dataset-project-flow.md
+++ b/docs/dataset-project-flow.md
@@ -132,4 +132,4 @@ Questo step e' opzionale: ha senso soprattutto se il dataset e' periodico, ha un
 
 Per i puntatori ai workflow pubblici nelle repo del Lab:
 
-- [workflows.md](workflows.md)
+- [workflows](/docs/workflows/)

--- a/docs/governance-model.md
+++ b/docs/governance-model.md
@@ -59,12 +59,12 @@ E' un ruolo trasversale, non un gradino della scala: un contributor puo' essere 
 - Per lavorare su una issue, lascia un commento — un maintainer risponde entro 7 giorni.
 - I core contributor emergono quando iniziano a reggere un filone nel tempo.
 
-Se non sai da dove partire, leggi [`docs/come-contribuire.md`](come-contribuire.md).
+Se non sai da dove partire, leggi [come-contribuire](/docs/come-contribuire/).
 
 ## Come nasce un nuovo progetto
 
 Il flusso canonico dal scouting di un dataset alla pubblicazione e' in
-[docs/dataset-project-flow.md](dataset-project-flow.md).
+[dataset-project-flow](/docs/dataset-project-flow/).
 
 ## Principio guida
 

--- a/docs/maintainer-playbook.md
+++ b/docs/maintainer-playbook.md
@@ -26,7 +26,7 @@ Prima di aprire un nuovo repo, controlla che:
 - il perimetro sia abbastanza piccolo da poter partire bene
 
 Prima di decidere se aprire subito una repo dedicata, passa dal flusso canonico del Lab:
-- [dataset-project-flow.md](dataset-project-flow.md)
+- [dataset-project-flow](/docs/dataset-project-flow/)
 
 In molti casi il percorso giusto non è ancora `Discussion -> repo`, ma:
 - `Discussion -> issue -> dataset-incubator`

--- a/docs/repository-map.md
+++ b/docs/repository-map.md
@@ -35,7 +35,7 @@ Dentro `dataciviclab` ci sono due livelli utili:
 
 Per orientarti tra i workflow pubblici cross-repo del Lab:
 
-- [workflows.md](workflows.md)
+- [workflows](/docs/workflows/)
 
 ## `.github`
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -70,4 +70,4 @@ leggere gli output e distinguere tra run riuscito e blocco tecnico reale.
 
 Se vuoi il quadro generale del funnel:
 
-- [dataset-project-flow.md](dataset-project-flow.md)
+- [dataset-project-flow](/docs/dataset-project-flow/)


### PR DESCRIPTION
## Problema

I link tra pagine docs usavano path relativi a file `.md` (es. `[workflows.md](workflows.md)`). Nel sito Astro, il browser da `/docs/dataset-project-flow/` risolve `workflows.md` come `/docs/dataset-project-flow/workflows.md` → 404.

## Root cause

Astro non riscrive i link markdown. I path relativi a `.md` vengono "appesi" alla pagina corrente invece di puntare alla destinazione corretta.

## Fix

Sostituiti 10 link in 6 file: `[foo.md](foo.md)` → `[foo](/docs/foo/)`.

| File | Link corretti |
|---|---|
| `come-contribuire.md` | dataset-project-flow, workflows, local-setup, governance-model |
| `dataset-project-flow.md` | workflows |
| `governance-model.md` | come-contribuire, dataset-project-flow |
| `maintainer-playbook.md` | dataset-project-flow |
| `repository-map.md` | workflows |
| `workflows.md` | dataset-project-flow |

Build locale verificato: il dist ora ha `href="/docs/workflows/"`.

## Prevenzione futura

Il workflow `docs.yml` andrebbe esteso con una regola che blocca link relativi a `.md` tra pagine docs, ma richiede un redesign del check (che attualmente valida solo path filesystem, non path del sito). Rimandato a issue/PR separata.