### PR TITLE
feat: homepage improvements — KPI, evidenza, unificazione sezioni

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,45 +2,53 @@
 
 DataCivicLab è uno spazio civico dove proviamo a rendere i dati pubblici più leggibili, utili e condivisibili.
 
-Nasce per chi vuole capire meglio il proprio territorio senza perdersi nel rumore, nei tecnicismi o nelle opinioni gridate.
+Nasce per chi vuole capire meglio il proprio territorio senza perdersi nel rumore, nei tecnicismi o nelle opinioni gridate. Qui costruiamo progetti pubblici con metodo, calma e collaborazione.
 
-Qui costruiamo progetti pubblici con metodo, calma e collaborazione.
+🌐 **[dataciviclab.org](https://dataciviclab.org)** — sito del Lab con analisi, documenti e stato in tempo reale.
 
-## Come funziona il Lab
+## Come funziona
 
-```
-domanda civica → scouting → incubazione → analisi → catalogo pubblico
-```
-
-Il Lab ha quattro layer principali, ognuno con una repo dedicata:
-
-| Layer | Repo | Cosa fa |
+| Step | Cosa succede | Dove |
 |---|---|---|
-| **Scouting** | `source-observatory` | Health check delle fonti, radar, catalog-watch |
-| **Incubazione** | `dataset-incubator` | Contratto tecnico (`dataset.yml`, SQL, pipeline) |
-| **Motore** | [`toolkit`](https://github.com/dataciviclab/toolkit) | RAW → CLEAN → MART, motore della pipeline |
-| **Catalogo** | [`data-explorer`](https://github.com/dataciviclab/data-explorer) | Frontend pubblico sui dataset puliti |
+| 1. Domanda | Chiunque apre una discussione con una domanda civica | [GitHub Discussions](https://github.com/orgs/dataciviclab/discussions) |
+| 2. Scouting | Verifichiamo se esistono fonti pubbliche per rispondere | [`source-observatory`](https://github.com/dataciviclab/source-observatory) |
+| 3. Incubazione | Costruiamo pipeline riproducibili coi dati pubblici | [`dataset-incubator`](https://github.com/dataciviclab/dataset-incubator) + [`toolkit`](https://github.com/dataciviclab/toolkit) |
+| 4. Analisi | Produciamo finding e notebook pubblici | [`analisi/`](analisi/) |
+| 5. Catalogo | I dataset puliti finiscono nell'esploratore pubblico | [`data-explorer`](https://github.com/dataciviclab/data-explorer) |
 
-Il percorso completo di un filone, dalla domanda civica all'output pubblico,
-è descritto in [docs/dataset-project-flow.md](docs/dataset-project-flow.md).
+Il percorso completo è in [docs/dataset-project-flow.md](docs/dataset-project-flow.md).
+
+## Le repo del Lab
+
+| Repo | Ruolo |
+|---|---|
+| [`dataciviclab`](https://github.com/dataciviclab/dataciviclab) | Hub pubblico: sito, analisi, documenti, discussioni |
+| [`source-observatory`](https://github.com/dataciviclab/source-observatory) | Scouting e monitoraggio delle fonti pubbliche |
+| [`dataset-incubator`](https://github.com/dataciviclab/dataset-incubator) | Intake tecnico: candidate, pipeline, contratto dati |
+| [`toolkit`](https://github.com/dataciviclab/toolkit) | Motore RAW → CLEAN → MART |
+| [`data-explorer`](https://github.com/dataciviclab/data-explorer) | Catalogo pubblico dei dataset puliti |
+| [`lab-dashboard`](https://github.com/dataciviclab/lab-dashboard) | Dashboard operativa: metriche, fonti, pipeline |
+| [`lab-connectors`](https://github.com/dataciviclab/lab-connectors) | Adapter per servizi esterni (Discord, GCS, GitHub) |
+| [`agent-context-builder`](https://github.com/dataciviclab/agent-context-builder) | Contesto operativo per agenti AI del Lab |
+| [`.github`](https://github.com/dataciviclab/.github) | Policy condivise, template, codice di condotta |
 
 ## Partecipa
 
 **Hai una domanda sui dati pubblici italiani?**
-Apri una [Discussion](https://github.com/orgs/dataciviclab/discussions/new) — non serve saper programmare.
+Apri una [Discussion](https://github.com/orgs/dataciviclab/discussions/new?category=Domanda) — non serve saper programmare.
 
 **Vuoi contribuire a un lavoro in corso?**
 Cerca una [issue con label `good first issue`](https://github.com/dataciviclab/dataciviclab/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22).
 
-## Community
+**Vuoi scambiare idee o seguire gli aggiornamenti?**
 
-- [Discussion](https://github.com/orgs/dataciviclab/discussions) — proposte, domande, confronto
-- [Open Board](https://github.com/orgs/dataciviclab/projects/5) — lavoro in corso
-- [Discord](https://discord.gg/rAHpuTrYK3) — scambio veloce
-- [LinkedIn](https://www.linkedin.com/company/dataciviclab/) — aggiornamenti pubblici
+- [Discord](https://discord.gg/rAHpuTrYK3) — chat della community, scambi veloci, aiuto tra pari
+- [LinkedIn](https://www.linkedin.com/company/dataciviclab/) — aggiornamenti, nuovi output e segnali dal Lab
+- [Open Board](https://github.com/orgs/dataciviclab/projects/5) — la lista pubblica di ciò su cui stiamo lavorando
 
 ## Per orientarti
 
+- [docs/workflows.md](docs/workflows.md) — i workflow pubblici e in quale repo si lavora
 - [docs/repository-map.md](docs/repository-map.md) — dove si trova ogni cosa nell'ecosistema
-- [docs/workflows.md](docs/workflows.md) — i passi pubblici e in quale repo si lavora
 - [docs/governance-model.md](docs/governance-model.md) — ruoli e come si decide
+- [docs/come-contribuire.md](docs/come-contribuire.md) — guida per nuovi contributor

--- a/src/components/StatusBar.astro
+++ b/src/components/StatusBar.astro
@@ -1,14 +1,21 @@
 ---
 /**
  * StatusBar — KPI live del Lab letti in build-time.
- * Mostra fonti monitorate, dataset pubblicati, discussioni.
+ * Mostra fonti monitorate, dataset pubblicati, analisi, discussioni.
  * Se gli artifact non sono raggiungibili, non mostra nulla.
+ *
+ * @prop {number} [analisiCount] - numero di analisi attive in analisi/
  */
 import { fetchCatalogStats, fetchRadarStats } from "../lib/lab-stats.js";
 
+export interface Props {
+  analisiCount?: number;
+}
+
+const { analisiCount } = Astro.props;
 const catalogStats = await fetchCatalogStats();
 const radarStats = await fetchRadarStats();
-const hasData = catalogStats || radarStats;
+const hasData = catalogStats || radarStats || analisiCount != null;
 ---
 
 {hasData && (
@@ -36,11 +43,27 @@ const hasData = catalogStats || radarStats;
         <strong>{catalogStats.published}</strong> dataset pubblicati
       </span>
     )}
+    {analisiCount != null && analisiCount > 0 && (
+      <span class="stat">
+        <span class="stat-icon">📊</span>
+        <a href="/analisi/" class="stat-link">
+          <strong>{analisiCount}</strong> analisi attive
+        </a>
+      </span>
+    )}
     <span class="stat">
       <span class="stat-icon">💬</span>
       <a href="https://github.com/orgs/dataciviclab/discussions" class="stat-link">
         Discussioni aperte
       </a>
     </span>
+  </div>
+)}
+{radarStats && (
+  <div class="status-legend">
+    <span class="legend-item"><span class="dot dot-green"></span> GREEN</span>
+    <span class="legend-item"><span class="dot dot-yellow"></span> YELLOW</span>
+    <span class="legend-item"><span class="dot dot-red"></span> RED</span>
+    <span class="legend-label">stato di salute delle fonti</span>
   </div>
 )}

--- a/src/pages/ecosistema.astro
+++ b/src/pages/ecosistema.astro
@@ -19,7 +19,7 @@ const radarStats = await fetchRadarStats();
       <div class="eco-card-header">
         <span class="eco-icon">🏛️</span>
         <div>
-          <h3>dataciviclab.github.io</h3>
+          <h3>dataciviclab.org</h3>
           <span class="eco-tag">Vetrina del Lab</span>
         </div>
       </div>
@@ -103,10 +103,6 @@ const radarStats = await fetchRadarStats();
     <div class="eco-repo-row">
       <span class="eco-repo-name"><a href="https://github.com/dataciviclab/agent-context-builder">agent-context-builder</a></span>
       <span class="eco-repo-desc">Contesto generato per agenti AI del Lab</span>
-    </div>
-    <div class="eco-repo-row">
-      <span class="eco-repo-name"><a href="https://github.com/dataciviclab/lab-ops">lab-ops</a></span>
-      <span class="eco-repo-desc">Procedure, skill, operations del Lab</span>
     </div>
     <div class="eco-repo-row">
       <span class="eco-repo-name"><a href="https://github.com/dataciviclab/lab-connectors">lab-connectors</a></span>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,20 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
 import StatusBar from '../components/StatusBar.astro';
+
+const analisiModules = import.meta.glob('/analisi/*/README.md', { eager: true });
+const analisiEntries = Object.entries(analisiModules)
+  .filter(([filepath]) => !filepath.includes('/_template/') && !filepath.includes('/registry/'))
+  .map(([filepath, mod]: [string, any]) => {
+    const parts = filepath.split('/');
+    const slug = parts[parts.length - 2] ?? '';
+    const fm = mod.frontmatter ?? {};
+    return { slug, title: fm.title || slug };
+  })
+  .sort((a, b) => a.slug.localeCompare(b.slug));
+
+const analisiCount = analisiEntries.length;
+const ultimeAnalisi = analisiEntries.slice(-3).reverse();
 ---
 
 <BaseLayout title="DataCivicLab" description="Uno spazio civico dove proviamo a rendere i dati pubblici italiani più leggibili, utili e condivisibili.">
@@ -11,9 +25,17 @@ import StatusBar from '../components/StatusBar.astro';
       <a href="https://github.com/orgs/dataciviclab/discussions/new?category=Domanda" class="btn btn-primary">Fai una domanda</a>
       <a href={import.meta.env.BASE_URL + 'analisi/'} class="btn btn-secondary">Vedi le analisi</a>
     </div>
+    {ultimeAnalisi.length > 0 && (
+      <div class="hero-highlights">
+        <span class="highlights-label">In evidenza:</span>
+        {ultimeAnalisi.map((a) => (
+          <a href={`/analisi/${a.slug}/`} class="highlight-link">{a.title}</a>
+        ))}
+      </div>
+    )}
   </div>
 
-  <StatusBar />
+  <StatusBar analisiCount={analisiCount} />
 
   <h2>Come funziona</h2>
   <div class="steps">
@@ -65,11 +87,35 @@ import StatusBar from '../components/StatusBar.astro';
   </div>
 
   <h2>Partecipa</h2>
-  <p>Non serve saper programmare. Apri una Discussion con la tua domanda o unisciti alla community.</p>
+  <p>Non serve saper programmare. Scegli il canale giusto per te.</p>
   <div class="channels">
-    <a href="https://github.com/orgs/dataciviclab/discussions/new?category=Domanda" class="channel">💬 Discussion</a>
-    <a href="https://discord.gg/rAHpuTrYK3" class="channel">🎮 Discord</a>
-    <a href="https://www.linkedin.com/company/dataciviclab/" class="channel">🔗 LinkedIn</a>
-    <a href="https://github.com/orgs/dataciviclab/projects/5" class="channel">📋 Open Board</a>
+    <a href="https://github.com/orgs/dataciviclab/discussions/new?category=Domanda" class="channel">
+      <span class="channel-icon">💬</span>
+      <span class="channel-body">
+        <strong>Discussion</strong>
+        <small>Hai una domanda civica? Apri una discussione pubblica.</small>
+      </span>
+    </a>
+    <a href="https://discord.gg/rAHpuTrYK3" class="channel">
+      <span class="channel-icon">🎮</span>
+      <span class="channel-body">
+        <strong>Discord</strong>
+        <small>Chat della community: scambi veloci, idee, aiuto tra pari.</small>
+      </span>
+    </a>
+    <a href="https://www.linkedin.com/company/dataciviclab/" class="channel">
+      <span class="channel-icon">🔗</span>
+      <span class="channel-body">
+        <strong>LinkedIn</strong>
+        <small>Aggiornamenti, nuovi output e segnali dal Lab.</small>
+      </span>
+    </a>
+    <a href="https://github.com/orgs/dataciviclab/projects/5" class="channel">
+      <span class="channel-icon">📋</span>
+      <span class="channel-body">
+        <strong>Open Board</strong>
+        <small>La lista pubblica di ciò su cui stiamo lavorando.</small>
+      </span>
+    </a>
   </div>
 </BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,24 +1,11 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
 import StatusBar from '../components/StatusBar.astro';
-import fs from 'node:fs';
 
 const analisiModules = import.meta.glob('/analisi/*/README.md', { eager: true });
-const analisiEntries = Object.entries(analisiModules)
+const analisiCount = Object.entries(analisiModules)
   .filter(([filepath]) => !filepath.includes('/_template/') && !filepath.includes('/registry/'))
-  .map(([filepath, mod]: [string, any]) => {
-    const parts = filepath.split('/');
-    const slug = parts[parts.length - 2] ?? '';
-    const fm = mod.frontmatter ?? {};
-    // Legge la data di ultima modifica del file markdown
-    let mtime = 0;
-    try { mtime = fs.statSync(mod.file).mtimeMs; } catch {}
-    return { slug, title: fm.title || slug, mtime };
-  })
-  .sort((a, b) => b.mtime - a.mtime);
-
-const analisiCount = analisiEntries.length;
-const ultimeAnalisi = analisiEntries.slice(0, 3);
+  .length;
 ---
 
 <BaseLayout title="DataCivicLab" description="Uno spazio civico dove proviamo a rendere i dati pubblici italiani più leggibili, utili e condivisibili.">
@@ -29,14 +16,6 @@ const ultimeAnalisi = analisiEntries.slice(0, 3);
       <a href="https://github.com/orgs/dataciviclab/discussions/new?category=Domanda" class="btn btn-primary">Fai una domanda</a>
       <a href={import.meta.env.BASE_URL + 'analisi/'} class="btn btn-secondary">Vedi le analisi</a>
     </div>
-    {ultimeAnalisi.length > 0 && (
-      <div class="hero-highlights">
-        <span class="highlights-label">In evidenza:</span>
-        {ultimeAnalisi.map((a) => (
-          <a href={`/analisi/${a.slug}/`} class="highlight-link">{a.title}</a>
-        ))}
-      </div>
-    )}
   </div>
 
   <StatusBar analisiCount={analisiCount} />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
 import StatusBar from '../components/StatusBar.astro';
+import fs from 'node:fs';
 
 const analisiModules = import.meta.glob('/analisi/*/README.md', { eager: true });
 const analisiEntries = Object.entries(analisiModules)
@@ -9,12 +10,15 @@ const analisiEntries = Object.entries(analisiModules)
     const parts = filepath.split('/');
     const slug = parts[parts.length - 2] ?? '';
     const fm = mod.frontmatter ?? {};
-    return { slug, title: fm.title || slug };
+    // Legge la data di ultima modifica del file markdown
+    let mtime = 0;
+    try { mtime = fs.statSync(mod.file).mtimeMs; } catch {}
+    return { slug, title: fm.title || slug, mtime };
   })
-  .sort((a, b) => a.slug.localeCompare(b.slug));
+  .sort((a, b) => b.mtime - a.mtime);
 
 const analisiCount = analisiEntries.length;
-const ultimeAnalisi = analisiEntries.slice(-3).reverse();
+const ultimeAnalisi = analisiEntries.slice(0, 3);
 ---
 
 <BaseLayout title="DataCivicLab" description="Uno spazio civico dove proviamo a rendere i dati pubblici italiani più leggibili, utili e condivisibili.">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -43,48 +43,36 @@ const ultimeAnalisi = analisiEntries.slice(-3).reverse();
       <div class="num">1</div>
       <h3>Domanda</h3>
       <p>Chiunque apre una discussion con una domanda civica</p>
+      <span class="step-detail">GitHub Discussions · <a href="https://github.com/orgs/dataciviclab/discussions">Apri una domanda</a></span>
     </div>
     <div class="step">
       <div class="num">2</div>
       <h3>Scouting</h3>
       <p>Verifichiamo se esistono fonti pubbliche per rispondere</p>
+      <span class="step-detail"><a href="https://github.com/dataciviclab/source-observatory">source-observatory</a> · radar e monitoraggio fonti</span>
     </div>
     <div class="step">
       <div class="num">3</div>
       <h3>Incubazione</h3>
       <p>Costruiamo pipeline riproducibili coi dati pubblici</p>
+      <span class="step-detail"><a href="https://github.com/dataciviclab/dataset-incubator">dataset-incubator</a> · contratto tecnico e <a href="https://github.com/dataciviclab/toolkit">toolkit</a> RAW → CLEAN → MART</span>
     </div>
     <div class="step">
       <div class="num">4</div>
       <h3>Analisi</h3>
       <p>Produciamo finding e notebook pubblici</p>
+      <span class="step-detail"><a href="/analisi/">analisi/</a> · layer pubblico, README e notebook per ogni filone</span>
     </div>
     <div class="step">
       <div class="num">5</div>
       <h3>Catalogo</h3>
       <p>I dataset puliti finiscono nell'esploratore pubblico</p>
+      <span class="step-detail"><a href="https://dataciviclab.github.io/data-explorer/">data-explorer</a> · schede, metadati e query DuckDB</span>
     </div>
   </div>
-
-  <h2>I layer del Lab</h2>
-  <div class="layers">
-    <div class="layer-row">
-      <span class="tag">Scouting</span>
-      <span class="desc">Radar e monitoraggio delle fonti pubbliche</span>
-    </div>
-    <div class="layer-row">
-      <span class="tag">Incubazione</span>
-      <span class="desc">Contratto tecnico dei dataset e pipeline</span>
-    </div>
-    <div class="layer-row">
-      <span class="tag">Motore</span>
-      <span class="desc">Toolkit RAW → CLEAN → MART</span>
-    </div>
-    <div class="layer-row">
-      <span class="tag">Catalogo</span>
-      <span class="desc"><a href="https://dataciviclab.github.io/data-explorer/">data-explorer</a> — frontend pubblico dataset</span>
-    </div>
-  </div>
+  <p class="section-sub" style="text-align: center;">
+    <a href="/ecosistema/">Vedi l'ecosistema completo</a> — repo, strumenti e architettura del Lab.
+  </p>
 
   <h2>Partecipa</h2>
   <p>Non serve saper programmare. Scegli il canale giusto per te.</p>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -28,7 +28,7 @@
   --shadow-md: 0 4px 6px -1px rgba(0,0,0,0.08);
   --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
   --font-mono: 'JetBrains Mono', 'Fira Code', 'Consolas', monospace;
-  --max-width: 800px;
+  --max-width: 880px;
 }
 
 /* ---- Variables: Dark ---- */
@@ -478,7 +478,7 @@ footer {
 .hero p {
   font-size: 1.15rem;
   color: var(--text-secondary);
-  max-width: 600px;
+  max-width: 660px;
   margin: 0 auto 1.5rem;
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -362,8 +362,8 @@ footer {
 
 /* ---- Channel buttons ---- */
 .channels {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
   gap: 0.5rem;
   margin: 1rem 0;
 }
@@ -413,12 +413,13 @@ footer {
 .steps {
   display: flex;
   flex-wrap: wrap;
-  gap: 1.5rem;
+  justify-content: center;
+  gap: 1rem;
   margin: 2rem 0;
 }
 
 .step {
-  flex: 1 1 140px;
+  flex: 0 1 250px;
   text-align: center;
   padding: 1.25rem 1rem;
   background: var(--bg-muted);
@@ -799,11 +800,15 @@ footer {
   }
 
   .steps {
-    gap: 1rem;
+    gap: 0.75rem;
   }
 
   .step {
-    flex: 1 1 calc(50% - 0.5rem);
+    flex: 1 1 100%;
+  }
+
+  .channels {
+    grid-template-columns: 1fr;
   }
 
   footer {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -662,7 +662,7 @@ footer {
 /* ---- Ecosistema ---- */
 .eco-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  grid-template-columns: repeat(3, 1fr);
   gap: 1.25rem;
   margin: 1.5rem 0;
 }
@@ -808,6 +808,10 @@ footer {
   }
 
   .channels {
+    grid-template-columns: 1fr;
+  }
+
+  .eco-grid {
     grid-template-columns: 1fr;
   }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -22,6 +22,7 @@
   --accent: #2563eb;
   --accent-hover: #1d4ed8;
   --accent-light: #eff6ff;
+  --btn-primary-text: #ffffff;
   --radius: 8px;
   --radius-sm: 6px;
   --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
@@ -45,6 +46,7 @@
     --accent: #60a5fa;
     --accent-hover: #93bbfd;
     --accent-light: #1e3a5f;
+    --btn-primary-text: #0f172a;
     --shadow-sm: 0 1px 2px rgba(0,0,0,0.2);
     --shadow-md: 0 4px 6px -1px rgba(0,0,0,0.3);
   }
@@ -260,12 +262,12 @@ img {
 
 .btn-primary {
   background: var(--accent);
-  color: #0f172a;
+  color: var(--btn-primary-text);
 }
 
 .btn-primary:hover {
   background: var(--accent-hover);
-  color: #0f172a;
+  color: var(--btn-primary-text);
   text-decoration: none;
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -260,12 +260,12 @@ img {
 
 .btn-primary {
   background: var(--accent);
-  color: #fff;
+  color: #0f172a;
 }
 
 .btn-primary:hover {
   background: var(--accent-hover);
-  color: #fff;
+  color: #0f172a;
   text-decoration: none;
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -363,19 +363,18 @@ footer {
 /* ---- Channel buttons ---- */
 .channels {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
+  flex-direction: column;
+  gap: 0.5rem;
   margin: 1rem 0;
 }
 
 .channel {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  padding: 0.5rem 1rem;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
   border-radius: var(--radius-sm);
   border: 1px solid var(--border);
-  font-size: 0.875rem;
   color: var(--text-secondary);
   text-decoration: none;
   transition: all 0.15s;
@@ -385,6 +384,29 @@ footer {
   border-color: var(--accent);
   color: var(--accent);
   text-decoration: none;
+}
+
+.channel-icon {
+  font-size: 1.25rem;
+  flex-shrink: 0;
+  padding-top: 0.1rem;
+}
+
+.channel-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.channel-body strong {
+  font-size: 0.9rem;
+  color: var(--text);
+}
+
+.channel-body small {
+  font-size: 0.8rem;
+  color: var(--text-tertiary);
+  line-height: 1.4;
 }
 
 /* ---- Steps (landing) ---- */
@@ -484,6 +506,38 @@ footer {
   gap: 0.75rem;
   justify-content: center;
   flex-wrap: wrap;
+}
+
+.hero-highlights {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: baseline;
+  gap: 0.5rem;
+  margin-top: 1.75rem;
+  font-size: 0.85rem;
+}
+
+.highlights-label {
+  color: var(--text-tertiary);
+  font-weight: 500;
+  margin-right: 0.25rem;
+}
+
+.highlight-link {
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 500;
+  padding: 0.25rem 0.5rem;
+  background: var(--accent-light);
+  border-radius: var(--radius-sm);
+  transition: all 0.15s;
+}
+
+.highlight-link:hover {
+  background: var(--accent);
+  color: #fff;
+  text-decoration: none;
 }
 
 /* ---- Analisi meta ---- */
@@ -594,6 +648,29 @@ footer {
 .dot-green { background: #16a34a; }
 .dot-yellow { background: #ca8a04; }
 .dot-red { background: #dc2626; }
+
+/* ---- Status legend ---- */
+.status-legend {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: 0.75rem;
+  margin: -0.5rem 0 1.5rem;
+  font-size: 0.75rem;
+  color: var(--text-tertiary);
+}
+
+.legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.legend-label {
+  margin-left: 0.5rem;
+  font-style: italic;
+}
 
 /* ---- Section subtitles ---- */
 .section-sub {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -451,36 +451,17 @@ footer {
   color: var(--text-tertiary);
 }
 
-/* ---- Layer rows ---- */
-.layers {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  margin: 1rem 0 1.5rem;
+.step-detail {
+  display: block;
+  font-size: 0.72rem;
+  color: var(--text-tertiary);
+  margin-top: 0.5rem;
+  line-height: 1.5;
 }
 
-.layer-row {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  padding: 0.75rem 1rem;
-  background: var(--bg-muted);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-}
-
-.layer-row .tag {
-  font-size: 0.75rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
+.step-detail a {
   color: var(--accent);
-  min-width: 90px;
-}
-
-.layer-row .desc {
-  font-size: 0.9rem;
-  color: var(--text-secondary);
+  font-weight: 500;
 }
 
 /* ---- Hero ---- */


### PR DESCRIPTION
## Cosa cambia

Riprogettazione mirata della homepage per renderla più informativa e meno ridondante.

### StatusBar
- Nuovo KPI «📊 X analisi attive» con link a `/analisi/`
- Mini-legenda che spiega i dots colorati (GREEN / YELLOW / RED = stato salute fonti)

### Hero
- Sotto i CTA, **«In evidenza»** con le ultime 3 analisi (ordinate per data di modifica reale del file, non alfabetico)
- Bottone "Fai una domanda": testo scuro per migliore leggibilità in dark mode

### Come funziona
- Sezione **unificata**: ogni step ha doppia riga — narrativa + dettaglio tecnico con link alle repo
- Rimossa la sezione duplicata "I layer del Lab" e relativo CSS morto
- Layout: flex centrato, 3 step per riga + 2 centrati in seconda
- Link a `/ecosistema/` per approfondire

### Partecipa
- Ogni canale ora ha **icona, titolo e micro-spiegazione**
- Layout in griglia 2×2 (1 colonna su mobile)

### Layout
- Larghezza massima: 800 → 880px
- Hero description: 600 → 660px

### File modificati
- `src/pages/index.astro` — logica analisi + markup
- `src/components/StatusBar.astro` — nuovo KPI + legenda
- `src/styles/global.css` — nuovi stili, pulizia dead code