### PR TITLE
quick-fix: RSS, robots.txt, Google Fonts self-host, smoke test

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -28,7 +28,7 @@ jobs:
         run: npm ci
 
       - name: Build preview
-        run: npm run build
+        run: npm test
         env:
           BASE_PATH: /pr-preview/${{ github.event.number }}
 

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -32,7 +32,7 @@ jobs:
         run: npm ci
 
       - name: Build site
-        run: npm run build
+        run: npm test
 
       - name: Deploy to gh-pages
         uses: peaceiris/actions-gh-pages@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@astrojs/rss": "^4.0.18",
         "@astrojs/sitemap": "^3.7.2",
+        "@fontsource/inter": "^5.2.8",
         "astro": "^6.3.5"
       }
     },
@@ -1937,6 +1938,15 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@fontsource/inter": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.2.8.tgz",
+      "integrity": "sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@img/colour": {

--- a/package.json
+++ b/package.json
@@ -6,11 +6,13 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
-    "preview": "astro preview"
+    "preview": "astro preview",
+    "test": "node --test test/*.mjs"
   },
   "dependencies": {
     "@astrojs/rss": "^4.0.18",
     "@astrojs/sitemap": "^3.7.2",
+    "@fontsource/inter": "^5.2.8",
     "astro": "^6.3.5"
   }
 }

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://dataciviclab.org/sitemap-index.xml

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -28,9 +28,7 @@ const ogImageUrl = new URL('og-image.jpg', Astro.site).href;
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta name="twitter:card" content="summary_large_image" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="alternate" type="application/rss+xml" title="DataCivicLab — Analisi" href={baseUrl + 'analisi/rss.xml'} />
   </head>
   <body>
     <div class="layout">
@@ -65,6 +63,7 @@ const ogImageUrl = new URL('og-image.jpg', Astro.site).href;
             <a href="https://dataciviclab.github.io/data-explorer/">Catalogo dataset</a>
             <a href="https://dataciviclab-dashboard.streamlit.app/">Dashboard operativa</a>
             <a href="https://github.com/dataciviclab">GitHub</a>
+            <a href={baseUrl + 'analisi/rss.xml'}>Feed RSS analisi</a>
           </div>
           <div class="footer-links">
             <span class="footer-group-label">Lavori in corso</span>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,6 +2,12 @@
    DataCivicLab — Global Styles
    ============================================ */
 
+/* Inter font self-hosted (@fontsource/inter) */
+@import '@fontsource/inter/400.css';
+@import '@fontsource/inter/500.css';
+@import '@fontsource/inter/600.css';
+@import '@fontsource/inter/700.css';
+
 /* ---- Reset ---- */
 *, *::before, *::after {
   margin: 0;

--- a/test/smoke.mjs
+++ b/test/smoke.mjs
@@ -1,0 +1,20 @@
+/**
+ * Smoke test: verifica che il build Astro completi senza errori.
+ * Usa il test runner nativo di Node.js.
+ */
+import { describe, it } from 'node:test';
+import { execSync } from 'node:child_process';
+import assert from 'node:assert';
+
+describe('Astro build', () => {
+  it('should complete without errors', () => {
+    const output = execSync('npm run build 2>&1', {
+      encoding: 'utf-8',
+      timeout: 120_000,
+    });
+    assert.ok(
+      output.includes('Complete!'),
+      `Build output should contain "Complete!"\n\n${output.slice(-500)}`
+    );
+  });
+});


### PR DESCRIPTION
## Cosa cambia

| Cosa | Dettaglio |
|---|---|
| **RSS nel \<head\>** | `<link rel="alternate" type="application/rss+xml">` per feed reader |
| **RSS nel footer** | Link "Feed RSS analisi" sotto Piattaforme |
| **robots.txt** | `public/robots.txt` con link a `sitemap-index.xml` |
| **Google Fonts self-host** | Rimosso CDN Google Fonts, usato `@fontsource/inter` (400/500/600/700) |
| **Smoke test** | `npm test` → builda e verifica "Complete!" |

### Build
```
19 page(s) built in 5.62s
```

### Test
```
# tests 1
# pass 1
# fail 0
```