### PR TITLE
docs: aggiorna CONTRIBUTING.md — sito Astro, struttura corrente, riferimenti

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,23 +12,69 @@ Per le regole GitHub condivise dell'organizzazione, vedi
 
 `dataciviclab` è l'hub pubblico del Lab. Qui stanno:
 
-- Discussions
-- docs brevi di orientamento
-- `analisi/` come layer pubblico delle analisi in corso
-- `projects/` come indice dei filoni promossi a repo dedicata
-- task cross-repo e decisioni organizzative
+- **Sito** — [dataciviclab.org](https://dataciviclab.org) basato su **Astro** (`src/`, `public/`, `astro.config.mjs`)
+- **Discussions** — domande, idee, confronto pubblico
+- **`docs/`** — documenti di orientamento (dataset-project-flow, governance, come-contribuire, local-setup)
+- **`analisi/`** — layer pubblico delle analisi in corso
+- **`projects/`** — indice dei filoni promossi a repo dedicata
+- **`skills/`** — guide operative per agenti e contributor
+- Task cross-repo e decisioni organizzative
 
 Qui non stanno:
 
 - il contratto tecnico dei candidati (dataset.yml, sql, compose) — va in `dataset-incubator`
 - feature o bug del toolkit — va in `toolkit`
 - policy GitHub comuni — vanno in `.github`
+- package condivisi di infrastruttura — vanno in `lab-connectors`
+
+## Sito Astro (dataciviclab.org)
+
+Il sito è costruito con [Astro](https://astro.build/) e pubblicato su GitHub Pages.
+
+### Setup locale
+
+```bash
+npm install
+npm run dev
+```
+
+Apri http://localhost:4321
+
+### Build e preview
+
+```bash
+npm run build       # produce dist/
+npm run preview     # serve la build localmente
+```
+
+### Struttura
+
+```
+src/
+  components/   # componenti Astro riutilizzabili
+  layouts/      # layout di pagina
+  lib/          # utility e funzioni condivise
+  pages/        # pagine del sito
+    analisi/    # pagine delle analisi
+    docs/       # pagine dei documenti
+  styles/       # stili globali
+public/         # asset statici
+analisi/        # sorgente delle pagine analisi (notebook, README)
+docs/           # sorgente dei documenti in markdown
+```
+
+### Aggiungere o modificare contenuti
+
+- **Docs**: modifica i file `.md` in `docs/` — le pagine Astro in `src/pages/docs/` li inglobano
+- **Analisi**: i contenuti vivono in `analisi/<slug>/`, le pagine in `src/pages/analisi/` li referenziano
+- **Pagine nuove**: crea un file `.astro` in `src/pages/` seguendo la struttura esistente
 
 ## Quando aprire issue qui
 
 Apri una issue in `dataciviclab` se il lavoro riguarda:
 
 - docs o orientamento del Lab
+- miglioramenti al sito Astro (contenuti, layout, performance)
 - task cross-repo
 - decisioni organizzative
 - output pubblici già abbastanza maturi
@@ -38,4 +84,14 @@ Apri una issue in `dataciviclab` se il lavoro riguarda:
 - verifica se esiste già una issue o Discussion collegata
 - tieni il cambiamento piccolo e leggibile
 - spiega il perché, non solo il cosa
+- se tocchi il sito, verifica con `npm run build` che non ci siano errori
 - se tocchi il flusso tra repo, controlla [docs/dataset-project-flow.md](docs/dataset-project-flow.md)
+
+## Riferimenti
+
+- [README.md](README.md) — panoramica del Lab
+- [docs/come-contribuire.md](docs/come-contribuire.md) — guida per nuovi contributor
+- [docs/dataset-project-flow.md](docs/dataset-project-flow.md) — flusso dalla domanda all'analisi
+- [docs/governance-model.md](docs/governance-model.md) — ruoli e decisioni
+- [docs/local-setup.md](docs/local-setup.md) — setup tecnico locale
+- [`.github`](https://github.com/dataciviclab/.github) — policy condivise


### PR DESCRIPTION
Aggiornamento del `CONTRIBUTING.md` per riflettere la struttura corrente della repo, che ora include anche il sito Astro (dataciviclab.org).

Aggiunte:
- Riconoscimento del sito Astro: setup locale, build, struttura `src/`
- "Cosa NON sta qui" aggiornato con lab-connectors
- Sezione "Riferimenti" con link a docs e `.github`
- Quando aprire issue: ora include anche miglioramenti al sito

Parte dell'iniziativa per allineare i CONTRIBUTING di tutti i repo core del Lab.