### PR TITLE
feat: PR template per hub pubblico (analisi, sito Astro, docs, governance)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,52 @@
+## Sintesi
+
+Descrivi in poche righe cosa cambia e perché.
+
+## Contesto collegato
+
+Closes #
+
+## Cosa cambia
+
+- [ ] Nuova analisi o aggiornamento (analisi/)
+- [ ] Modifica sito Astro (src/, public/, astro.config.mjs)
+- [ ] Documenti di orientamento (docs/)
+- [ ] Governance / decisioni organizzative
+- [ ] Cross-repo task
+- [ ] Altro
+
+## Checklist
+
+### Se tocchi analisi/
+
+- [ ] `analisi/<slug>/README.md` presente e leggibile
+- [ ] Notebook o figure puliti (nessun path assoluto)
+- [ ] Issue pubblica o Discussion collegata nel corpo della PR
+
+### Se tocchi il sito Astro
+
+- [ ] `npm run build` produce `dist/` senza errori
+- [ ] Nessun warning critico in console durante `npm run dev`
+- [ ] Layout responsive verificato su mobile
+
+### Se tocchi docs/
+
+- [ ] Contenuto allineato ai principi del Lab (leggibile da esterni)
+- [ ] Link funzionanti
+
+### Se tocchi governance o processo
+
+- [ ] Decisione discussa prima in una issue o Discussion
+- [ ] Impatto su altri repo dichiarato
+
+## Verifica
+
+Spiega come hai verificato il cambiamento.
+
+- [ ] `npm run build` passa (se tocchi sito)
+- [ ] Perimetro piccolo e leggibile: una PR = un tema o un fix
+- [ ] Issue o Discussion collegata
+
+## Note per chi revisiona
+
+Rischi, limiti, punti da controllare con attenzione.


### PR DESCRIPTION
## Sintesi

Aggiunge PR template a dataciviclab, l'hub pubblico del Lab.

## Cosa cambia

| File | Descrizione |
|---|---|
| `.github/PULL_REQUEST_TEMPLATE.md` | PR template con checklist per: analisi/, sito Astro, docs/, governance, cross-repo |

## Perché

- dataciviclab riceve PR di tipo molto diverso (analisi, sito, docs, governance) che il template org generico non cattura
- Il CONTRIBUTING richiede `npm run build` per modifiche sito — ora è nel template

## Verifica

- Template statico, nessun codice modificato
