### PR TITLE
fix(analisi): completa registry active.md e allinea frontmatter README

### DIFF
--- a/analisi/_template/README.md
+++ b/analisi/_template/README.md
@@ -3,6 +3,8 @@ title: ""
 description: ""
 topics:
 status: active
+discussion:  # opzionale — numero della GitHub Discussion in categoria Analisi
+issue:  # opzionale — numero della GitHub Issue collegata
 dataset_slug: ""
 ---
 

--- a/analisi/aifa-spesa-consumo/README.md
+++ b/analisi/aifa-spesa-consumo/README.md
@@ -4,6 +4,7 @@ description: Quanto spende il SSN per i farmaci e dove vanno i soldi?
 date: 2026-05-24
 topics: sanita
 status: active
+discussion: 242
 dataset_slug: aifa_spesa_consumo
 ---
 # AIFA Spesa farmaceutica 2018-2024 — il cardiovascolare domina, la spesa totale si contrae

--- a/analisi/dipendenti-pubblici/README.md
+++ b/analisi/dipendenti-pubblici/README.md
@@ -4,6 +4,7 @@ date: 2026-03-14
 description: Come sta cambiando il pubblico impiego tra il 2010 e il 2023, e in quali comparti si concentra la dinamica?
 topics: lavoro, pubblica-amministrazione
 status: active
+issue: 131
 dataset_slug: dipendenti_pubblici
 ---
 # Dipendenti pubblici 2010-2023 — il declino, la svolta, i conti in tasca

--- a/analisi/entrate-stato/README.md
+++ b/analisi/entrate-stato/README.md
@@ -4,6 +4,7 @@ description: Le entrate dello Stato stanno cambiando composizione?
 date: 2026-05-24
 topics: economia, finanza-pubblica
 status: active
+discussion: 218
 dataset_slug: bdap_entrate_stato
 ---
 # Entrate dello Stato 2008-2024 — il peso dei prestiti raddoppia

--- a/analisi/irpef-comunale/README.md
+++ b/analisi/irpef-comunale/README.md
@@ -4,6 +4,7 @@ date: 2026-03-08
 description: Come varia la capacità fiscale tra comuni e regioni?
 topics: economia, fisco
 status: active
+discussion: 88
 dataset_slug: irpef_comunale
 ---
 # IRPEF comunale 2019-2023 — il divario fiscale in Italia

--- a/analisi/malasanita-struttura-mortalita/README.md
+++ b/analisi/malasanita-struttura-mortalita/README.md
@@ -4,6 +4,8 @@ date: 2026-03-12
 description: Le regioni con meno personale sanitario hanno tassi di mortalità evitabile più alti?
 topics: sanita
 status: active
+discussion: 99
+issue: 110
 ---
 # Malasanità 2022: mortalità evitabile e dotazione sanitaria regionale
 

--- a/analisi/registry/active.md
+++ b/analisi/registry/active.md
@@ -2,10 +2,15 @@
 
 | filone | discussion | issue | stato |
 |--------|------------|-------|-------|
-| irpef-comunale | [#88](https://github.com/orgs/dataciviclab/discussions/88) | — | active |
+| aifa-spesa-consumo | [#242](https://github.com/orgs/dataciviclab/discussions/242) | — | active |
+| camera-votazioni | — | — | active |
 | civile-flussi | — | — | active |
-| malasanita-struttura-mortalita | [#99](https://github.com/orgs/dataciviclab/discussions/99) | [#110](https://github.com/dataciviclab/dataciviclab/issues/110) | active |
-| terna-electricity-by-source | [#115](https://github.com/orgs/dataciviclab/discussions/115) | [#133](https://github.com/dataciviclab/dataciviclab/issues/133) | active |
+| consip-consumi-convenzione | — | — | active |
 | dipendenti-pubblici | — | [#131](https://github.com/dataciviclab/dataciviclab/issues/131) | active |
+| entrate-stato | [#218](https://github.com/orgs/dataciviclab/discussions/218) | — | active |
+| irpef-comunale | [#88](https://github.com/orgs/dataciviclab/discussions/88) | — | active |
+| malasanita-struttura-mortalita | [#99](https://github.com/orgs/dataciviclab/discussions/99) | [#110](https://github.com/dataciviclab/dataciviclab/issues/110) | active |
+| opencivitas-fsc-rso | — | — | active |
+| terna-electricity-by-source | [#115](https://github.com/orgs/dataciviclab/discussions/115) | [#133](https://github.com/dataciviclab/dataciviclab/issues/133) | active |
 
 I filoni archiviati sono in [archived.md](archived.md).

--- a/analisi/terna-electricity-by-source/README.md
+++ b/analisi/terna-electricity-by-source/README.md
@@ -4,6 +4,8 @@ date: 2026-03-14
 description: Il mix elettrico italiano si sta spostando dalle fonti fossili?
 topics: energia, ambiente
 status: active
+discussion: 115
+issue: 133
 dataset_slug: terna_electricity_by_source
 ---
 # Terna mix elettrico 2023-2024 — le rinnovabili sfiorano il 44%


### PR DESCRIPTION
## Sintesi

Completa il registro delle analisi attive con le 5 mancanti e allinea i README al nuovo meccanismo di discovery automatica di ACB (discussion/issue leggibili dal frontmatter invece che dal solo registry).

## Contesto collegato

Nessuna issue aperta — fix concordato col civic-director. Correlato a [agent-context-builder#51](https://github.com/dataciviclab/agent-context-builder/pull/51) (scoperta automatica analisi).

## Cosa cambia

- [x] Nuova analisi o aggiornamento (analisi/)
- [ ] Modifica sito Astro
- [ ] Documenti di orientamento
- [ ] Governance / decisioni organizzative
- [x] Cross-repo task
- [ ] Altro

**Dettaglio**:
- `analisi/registry/active.md`: aggiunte 5 analisi mancanti (da 5 a 10)
- `analisi/aifa-spesa-consumo/README.md`: + `discussion: 242`
- `analisi/entrate-stato/README.md`: + `discussion: 218`
- `analisi/irpef-comunale/README.md`: + `discussion: 88`
- `analisi/malasanita-struttura-mortalita/README.md`: + `discussion: 99`, `issue: 110`
- `analisi/terna-electricity-by-source/README.md`: + `discussion: 115`, `issue: 133`
- `analisi/dipendenti-pubblici/README.md`: + `issue: 131`
- `analisi/_template/README.md`: aggiunti campi `discussion:` e `issue:` opzionali

## Checklist

- [x] `analisi/<slug>/README.md` presente e leggibile
- [x] Notebook o figure puliti
- [x] Issue pubblica o Discussion collegata nel corpo della PR

## Verifica

- [x] Perimetro piccolo e leggibile: una PR = un fix
- [x] Build ACB verificato con 10 analisi scoperte

## Note per chi revisiona

Le 3 analisi `camera-votazioni`, `consip-consumi-convenzione`, `opencivitas-fsc-rso` sono state aggiunte al registry senza discussion/issue perché non ne hanno ancora una dedicata in categoria Analisi. Se ne avranno in futuro, basterà aggiungere il campo al frontmatter del README.