### PR TITLE
aggiorna dataset-funnel: 6 step skills-first, artifact tracker, tabella skills reali

### DIFF
--- a/.github/ISSUE_TEMPLATE/dataset-funnel.yml
+++ b/.github/ISSUE_TEMPLATE/dataset-funnel.yml
@@ -1,19 +1,20 @@
 name: Dataset journey (funnel)
-description: Traccia un filone dataset end-to-end nella Open Board del Lab.
+description: Traccia un percorso dataset end-to-end, dallo scouting alla pubblicazione.
 title: "dataset: [SLUG]"
 labels: ["dataset", "funnel"]
 body:
   - type: markdown
     attributes:
       value: |
-        Utilizza questa issue come **Issue Madre** per tracciare il percorso di un dataset nel Lab, dallo scouting iniziale alla pubblicazione.
-        Questa issue non sostituisce il lavoro tecnico (che vive in `dataset-incubator`) ma serve a consolidare il progresso nella Open Board.
+        Issue Madre per tracciare il percorso completo di un dataset nel Lab.
+        Ogni step corrisponde a una skill eseguibile. I link agli artifact
+        si compilano man mano che il filone avanza.
 
   - type: input
     id: slug
     attributes:
       label: Slug
-      description: Lo slug canonico del dataset (es. `istat-abitazioni-affitto-2023`).
+      description: Slug canonico del dataset (es. `istat-abitazioni-affitto-2023`).
       placeholder: es. istat-abitazioni-affitto-2023
     validations:
       required: true
@@ -22,7 +23,7 @@ body:
     id: civic_question
     attributes:
       label: Domanda civica
-      description: Qual e' la domanda pubblica o il gap che guida questo filone?
+      description: Quale domanda pubblica guida questo filone?
       placeholder: Formula la domanda in modo chiaro e analitico.
     validations:
       required: true
@@ -30,23 +31,45 @@ body:
   - type: input
     id: source
     attributes:
-      label: Fonte o dataset
-      description: Nome della fonte principale (es. ISTAT SDMX, ISPRA RDF, OpenBDAP).
+      label: Fonte principale
+      description: Ente, portale o URL della fonte (es. ISTAT SDMX, OpenBDAP, ...).
     validations:
       required: true
 
-  - type: dropdown
-    id: phase
+  - type: input
+    id: discussion_url
     attributes:
-      label: Fase attuale
-      description: Seleziona la fase corrente del funnel.
+      label: Discussion Domanda di riferimento
+      description: Link alla Discussion categoria Domanda in dataciviclab (se presente).
+      placeholder: https://github.com/orgs/dataciviclab/discussions/N
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: steps
+    attributes:
+      label: Avanzamento
+      description: Segna gli step completati. Si aggiorna man mano.
       options:
-        - "1. SCOUTING (source-check)"
-        - "2. VALIDATION (Reddit/Social signal)"
-        - "3. CONSOLIDATION (GitHub Discussion)"
-        - "4. INCUBATION (dataset-incubator)"
-        - "5. ANALYSIS (analisi/findings)"
-        - "6. PROMOTION (data-explorer - opzionale)"
+        - label: "1. Inventory-triage — shortlist item in source-observatory"
+        - label: "2. Source-check — fonte verificata, verdict `go intake`"
+        - label: "3. Intake-candidate — candidate strutturato e PR mergiata in dataset-incubator"
+        - label: "4. Post-merge — clean parquet su GCS e catalog aggiornato"
+        - label: "5. Add-to-explorer — dataset pubblicato su data-explorer"
+        - label: "6. New-analysis — analisi pubblicata in dataciviclab/analisi/"
+
+  - type: dropdown
+    id: status
+    attributes:
+      label: Stato corrente
+      description: Fase in cui si trova il filone adesso.
+      options:
+        - "Step 1 — Inventory-triage"
+        - "Step 2 — Source-check"
+        - "Step 3 — Intake-candidate"
+        - "Step 4 — Post-merge"
+        - "Step 5 — Add-to-explorer"
+        - "Step 6 — New-analysis"
         - "WATCHLIST"
         - "BLOCKED"
         - "NO-GO"
@@ -54,26 +77,27 @@ body:
       required: true
 
   - type: textarea
-    id: links
+    id: artifacts
     attributes:
-      label: Link utili
-      description: Incolla i link agli artifact man mano che vengono creati.
+      label: Artifact tracker
+      description: Link agli artifact man mano che vengono creati.
       placeholder: |
-        - Source-check (nota locale):
-        - Validation (post Reddit):
-        - Discussion (GitHub):
-        - Issue Intake (DI):
-        - PR Candidate (DI):
-        - Analisi (folder/PR):
-        - Explorer:
+        - Inventory-triage (issue SO #):
+        - Source-check (issue SO #):
+        - Discussion Domanda (#):
+        - Intake-candidate (issue DI #):
+        - PR Candidate (DI #):
+        - Post-merge (PR registry #):
+        - Add-to-explorer (PR explorer #):
+        - New-analysis (PR DCL #):
     validations:
       required: false
 
   - type: textarea
-    id: note
+    id: notes
     attributes:
-      label: Nota breve
-      description: Solo se serve a spiegare blocchi, scelte o cambi di rotta.
+      label: Note operative
+      description: Blocchi, decisioni, cambi di rotta — solo se serve.
     validations:
       required: false
 
@@ -81,10 +105,18 @@ body:
     attributes:
       value: |
         ---
-        **Guida alle skill del Lab**
-        - **SCOUTING**: usa la skill `source-check` per il primo audit tecnico.
-        - **VALIDATION**: usa draft Reddit o altri segnali esterni quando serve; non sempre e' obbligatoria.
-        - **CONSOLIDATION**: usa la skill `open-discussion` per creare l'artifact canonico.
-        - **INCUBATION**: usa la skill `intake-candidate` per il lavoro tecnico in DI.
-        - **ANALYSIS**: usa la skill `promote-analisi` per il layer narrativo.
-        - **PROMOTION**: usa la skill `add-to-explorer` per il catalogo pubblico.
+        **Skills collegate (eseguibili da agenti AI nel workspace)**
+
+        | Step | Skill | Repo |
+        |---|---|---|
+        | 1. Inventory-triage | `inventory-triage` | source-observatory |
+        | 2. Source-check | `source-check` | source-observatory |
+        | 3. Intake-candidate | `intake-candidate` | dataset-incubator |
+        | 4. Post-merge | `post-merge-candidate` | dataset-incubator |
+        | 5. Add-to-explorer | `add-to-explorer` | data-explorer |
+        | 6. New-analysis | `new-analysis` | dataciviclab |
+
+        **Passaggio tra step**: ogni skill produce l'input della successiva.
+        Se un filone viene da una segnalazione esterna (es. GitHub Discussion),
+        il percorso può partire dallo Step 2 — in quel caso segna lo Step 1
+        come `N/A` e spiega il motivo nelle note.


### PR DESCRIPTION
## Sintesi

Aggiornamento del template `dataset-funnel.yml` per allinearlo alle skills reali del Lab e alla sequenza end-to-end verificata.

I 6 step sostituiscono le vecchie fasi ibride (che includevano `VALIDATION` e `CONSOLIDATION` orfane e skills inesistenti) con una pipeline lineare dove ogni step corrisponde a una skill eseguibile nel workspace.

## Cosa cambia

- [ ] Nuova analisi o aggiornamento (analisi/)
- [ ] Modifica sito Astro (src/, public/, astro.config.mjs)
- [ ] Documenti di orientamento (docs/)
- [x] Governance / decisioni organizzative
- [ ] Cross-repo task
- [ ] Altro

## Checklist (governance)

- [x] Decisione discussa prima in una issue o Discussion
- [x] Impatto su altri repo dichiarato

## Dettaglio modifiche

| Campo | Vecchio | Nuovo |
|---|---|---|
| **Fasi** | 6 fasi ibride (SCOUTING, VALIDATION, CONSOLIDATION, INCUBATION, ANALYSIS, PROMOTION) | 6 step skills-first (Inventory-triage → Source-check → Intake-candidate → Post-merge → Add-to-explorer → New-analysis) |
| **Avanzamento** | solo dropdown "fase attuale" | checkbox per step completati + dropdown stato corrente separato |
| **Discussion Domanda** | assente | nuovo campo input (ancoraggio pubblico) |
| **Artifact tracker** | lista libera "Link utili" | tracker strutturato per step |
| **Skills reference** | skills obsolete (`open-discussion`, `promote-analisi`) | skills reali con tabella e repo |

## Impatto su altri repo

Il template elenca e linka skills in:
- `source-observatory` (inventory-triage, source-check)
- `dataset-incubator` (intake-candidate, post-merge-candidate)
- `data-explorer` (add-to-explorer)
- `dataciviclab` (new-analysis)

Nessun cambiamento funzionale in quei repo — è solo un allineamento delle reference.

## Verifica

- [x] YAML valido (struttura GitHub Issue Form)
- [x] Perimetro piccolo e leggibile: una PR = un template
- [x] Skills verificate una per una contro le specifiche canoniche

## Note per chi revisiona

- Le issue esistenti con `dataset-funnel` restano valide — il campo `phase` cambia nome in `status` ma le opzioni sono diverse: le issue vecchie avranno il dropdown disallineato. Da valutare se serve una migration o si lascia che le nuove usino il nuovo template.
- Se si vuole tenere traccia delle issue vecchie, si può aggiungere una label `legacy-funnel` e aggiornare a mano quelle ancora aperte.