### PR TITLE
chore: pre-commit hooks (hook base, analisi/ escluso)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,4 +7,3 @@
 *.txt text eol=lf
 *.sql text eol=lf
 *.py text eol=lf
-

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ __pycache__/
 node_modules/
 dist/
 .astro/
-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+# Pre-commit hooks per dataciviclab.
+# Installare con: pre-commit install
+# Run su tutti i file: pre-commit run --all-files
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+        exclude: '^analisi/'
+      - id: end-of-file-fixer
+        exclude: '^analisi/'
+      - id: check-yaml
+      - id: check-json
+      - id: check-added-large-files
+      - id: check-merge-conflict
+      - id: detect-private-key

--- a/docs/dataset-project-flow.md
+++ b/docs/dataset-project-flow.md
@@ -94,5 +94,3 @@ Domanda → Scouting → Incubazione → Analisi
 ```text
 Domanda → Scouting → Incubazione → Analisi → Catalogo (data-explorer)
 ```
-
-

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -242,5 +242,3 @@ img {
 .section-sub {
   margin-bottom: 2rem;
 }
-
-


### PR DESCRIPTION
## Sintesi

Aggiunge `.pre-commit-config.yaml` con hook standard (no ruff — sito Astro/markdown). `analisi/` escluso da hook modificanti (trailing-whitespace, end-of-file-fixer) per non alterare notebook e README delle analisi.

## Cosa cambia

- Nuovo `.pre-commit-config.yaml`
- Fix end-of-file su `.gitattributes`, `.gitignore`, `docs/`, `src/styles/`
- `analisi/` escluso

## Verifica

```bash
pre-commit install
pre-commit run --all-files
```
