### PR TITLE
docs: sidebar navigazione + glossario + FAQ

### DIFF
--- a/docs/come-contribuire.md
+++ b/docs/come-contribuire.md
@@ -1,6 +1,7 @@
 ---
 title: Come contribuire a DataCivicLab
 slug: come-contribuire
+description: Percorsi diversi per partecipare al Lab, anche senza saper programmare.
 ---
 # Come contribuire a DataCivicLab
 

--- a/docs/dataset-project-flow.md
+++ b/docs/dataset-project-flow.md
@@ -1,6 +1,7 @@
 ---
 title: Flusso dataset / progetto
 slug: dataset-project-flow
+description: Come il Lab trasforma una domanda civica in dati pubblici — dal scouting alla pubblicazione.
 ---
 
 # Flusso dataset / progetto

--- a/docs/domande-frequenti.md
+++ b/docs/domande-frequenti.md
@@ -1,0 +1,78 @@
+---
+title: Domande frequenti
+slug: domande-frequenti
+description: Risposte alle domande più comuni su DataCivicLab.
+---
+
+# Domande frequenti
+
+## Devo saper programmare per contribuire?
+
+No. Il punto di ingresso principale sono le Discussion — basta una domanda
+chiara su dati pubblici. Se vuoi contribuire con codice, ci sono `good first issue`
+in vari repo, ma non è l'unico modo.
+
+Vedi [come-contribuire](/docs/come-contribuire/).
+
+## Come faccio a proporre un'analisi?
+
+Apri una [Discussion](https://github.com/orgs/dataciviclab/discussions/new?category=Domanda)
+nella categoria **Domanda**. Spiega cosa vuoi capire e, se la conosci, indica la
+fonte pubblica che potrebbe servire. Il team la prende in carico.
+
+## Che differenza c'è tra Discussion e Issue?
+
+- **Discussion** — spazio per formulare domande, esplorare idee, chiarire prima di
+  decidere. Non richiede un'azione immediata.
+- **Issue** — task concreto e assegnabile. Si apre quando una discussione è matura
+  e serve un'azione specifica (aprire un intake, scrivere un'analisi, fixare un bug).
+
+## Come deciso cosa fare?
+
+Le priorità le tiene il maintainer, ma le idee nascono in pubblico (Discussion).
+La regola è: trasparenza e traccia su GitHub. Nessuna decisione importante si
+prende in privato.
+
+## Posso usare i dataset del Lab per mio progetto?
+
+Tutti i dataset pubblicati sono sotto licenza aperta (vedi `LICENSE` della repo).
+Puoi scaricarli, analizzarli, usarli in articoli o visualizzazioni. Se lo fai,
+citare la fonte originale e il Lab è apprezzato ma non obbligatorio.
+
+## I dati sono aggiornati?
+
+Dipende dalla fonte. I dataset periodici vengono ri-eseguiti alla cadenza della
+fonte (annuale, mensile, ecc.). Lo stato aggiornamento è visibile nel catalogo
+[data-explorer](https://dataciviclab.github.io/data-explorer/).
+
+## Perché alcuni dataset hanno anni che sembrano vecchi?
+
+Perché la fonte pubblica non ha ancora rilasciato dati più recenti.
+Non inventiamo dati. Se una fonte è ferma al 2023, il dataset è fermo al 2023.
+Il source-observatory monitora attivamente gli aggiornamenti.
+
+## Come faccio a segnalare un errore in un'analisi?
+
+Apri una issue nella repo `dataciviclab` con link all'analisi e descrizione
+dell'errore. Se hai dubbi, apri prima una Discussion. Ogni errore confermato
+viene corretto e tracciato.
+
+## Cos'è un "finding"?
+
+Un'affermazione verificabile supportata dai dati. Esempio: "Nel 2023 le
+rinnovabili hanno coperto il 38% del fabbisogno elettrico italiano".
+I finding sono l'unità di output pubblico del Lab. Ogni analisi ne produce
+3-5, con evidenza e limiti esplicitati.
+
+## Posso fare una domanda sul territorio (comune, regione, provincia)?
+
+Sì, purché la risposta richieda dati pubblici e non opinioni. Il Lab lavora
+su fenomeni misurabili, non su casi singoli non verificabili. Se la domanda
+è "Quanto ha speso il mio comune in X?", servono dati pubblici che coprano
+tutti i comuni — non possiamo fare richieste FOIA o ricerche ad hoc.
+
+## Come nantieni il Lab?
+
+DataCivicLab è un progetto volontario, senza finanziamenti. Il tempo è quello
+che i contributori riescono a dedicare. Per questo lavoriamo a rilascio
+continuo e priorizziamo output verificabili.

--- a/docs/glossario.md
+++ b/docs/glossario.md
@@ -1,0 +1,79 @@
+---
+title: Glossario
+slug: glossario
+description: Termini e concetti chiave del DataCivicLab, dal funnel ai layer della pipeline.
+---
+
+# Glossario
+
+Termini che compaiono nei documenti e nelle discussioni del Lab.
+
+---
+
+**Analisi**
+: Prodotto pubblico finale del Lab. Ogni analisi vive in `dataciviclab/analisi/<slug>/` con
+README, notebook e figure. Risponde a una domanda civica con dati verificabili.
+
+**Candidate**
+: Un dataset in fase di incubazione in `dataset-incubator`. Ha un `dataset.yml`, SQL di
+pulizia e trasformazione, e produce output RAW → CLEAN → MART. Prima di essere pubblicato
+supera una review.
+
+**CLEAN**
+: Secondo layer della pipeline. Dati normalizzati, con tipi consistenti, valori
+standardizzati e null gestiti. Pronto per analisi cross-dataset.
+
+**Dataset**
+: Fonte dati pubblica incanalata nel Lab. Può essere un file CSV, un'API, un dataflow SDMX.
+Ogni dataset ha un contratto (`dataset.yml`) che definisce fonte, periodicità e schema.
+
+**Domanda civica**
+: Punto di ingresso del funnel. Una domanda su un fenomeno pubblico
+(es. "Perché in Sicilia i tempi della giustizia sono più lunghi?") che guida la ricerca
+di dati e la successiva analisi. Chiunque può aprirne una.
+
+**Funnel**
+: Il percorso che va dalla domanda civica all'output pubblico:
+`Domanda → Scouting → Incubazione → Analisi → Catalogo`. Non è rigido — non tutte le
+domande arrivano in fondo.
+
+**Finding**
+: Un'affermazione verificabile supportata dai dati. Esempio: "Nel 2023 le rinnovabili
+hanno coperto il 38% del fabbisogno elettrico italiano". I finding sono l'unità di output
+del Lab.
+
+**Incubazione**
+: Fase in cui una fonte validata diventa un candidate tecnico. Include la scrittura del
+contratto (`dataset.yml`), delle SQL di pulizia, e la prima esecuzione della pipeline.
+
+**Intake**
+: Il passaggio da fonte scoutata a candidate aperto. Si formalizza con una issue in
+`dataset-incubator` con template intake.
+
+**Layer**
+: Ciascuno degli stadi della pipeline: RAW (dato originale), CLEAN (normalizzato),
+MART (aggregato per analisi). Ogni layer è un parquet su GCS con schema documentato.
+
+**MART**
+: Terzo layer della pipeline. Dati aggregati e pronti per l'analisi diretta.
+Ogni MART risponde a un uso specifico (es. serie storiche, ranking, distribuzioni).
+
+**Pipeline**
+: Il flusso automatizzato RAW → CLEAN → MART. Eseguito dal toolkit, configurato dal
+`dataset.yml`. Riproducibile e versionato.
+
+**RAW**
+: Primo layer della pipeline. Copia fedele del file originale, con il minimo di
+trasformazioni (encoding, delimiter). Non si modificano i valori.
+
+**Scouting**
+: Fase di verifica di una fonte pubblica. Si cerca, si scarica, si valuta se i dati sono
+utilizzabili. Se sì, si apre un intake. Se no, si spiega perché.
+
+**Source-check**
+: Workflow del source-observatory per verificare se una fonte pubblica merita un intake.
+Produce un esito: `go intake`, `watchlist` o `no-go`.
+
+**Toolkit**
+: Motore software che esegue la pipeline. Legge il `dataset.yml`, esegue gli step di
+pulizia e trasformazione, e produce i parquet su GCS.

--- a/docs/governance-model.md
+++ b/docs/governance-model.md
@@ -1,6 +1,7 @@
 ---
 title: Modello di governance
 slug: governance-model
+description: Ruoli, responsabilità e come si prendono le decisioni nel Lab.
 ---
 # Modello di governance
 

--- a/docs/local-setup.md
+++ b/docs/local-setup.md
@@ -1,6 +1,7 @@
 ---
 title: Setup locale minimo
 slug: local-setup
+description: Guida tecnica per contributori che vogliono eseguire la pipeline in locale.
 ---
 # Setup locale minimo
 

--- a/src/data/docs-nav.js
+++ b/src/data/docs-nav.js
@@ -1,0 +1,25 @@
+/**
+ * Ordine e metadati per la navigazione della sezione docs.
+ * Mantenuto centralizzato per coerenza sidebar + indice.
+ *
+ * Aggiungi qui una nuova pagina docs/ per farla comparire nella sidebar.
+ */
+export const docsNav = [
+  { slug: 'come-contribuire',     title: 'Come contribuire' },
+  { slug: 'dataset-project-flow', title: 'Flusso dataset / progetto' },
+  { slug: 'governance-model',     title: 'Modello di governance' },
+  { slug: 'glossario',            title: 'Glossario' },
+  { slug: 'domande-frequenti',    title: 'Domande frequenti' },
+  { slug: 'local-setup',          title: 'Setup locale' },
+];
+
+/** Recupera indice e link prev/next per una slug. */
+export function getNavContext(slug) {
+  const idx = docsNav.findIndex((e) => e.slug === slug);
+  if (idx === -1) return { current: null, prev: null, next: null };
+  return {
+    current: docsNav[idx],
+    prev: idx > 0 ? docsNav[idx - 1] : null,
+    next: idx < docsNav.length - 1 ? docsNav[idx + 1] : null,
+  };
+}

--- a/src/layouts/DocsLayout.astro
+++ b/src/layouts/DocsLayout.astro
@@ -1,0 +1,205 @@
+---
+import BaseLayout from './BaseLayout.astro';
+import { docsNav, getNavContext } from '../data/docs-nav.js';
+
+export interface Props {
+  title: string;
+  description?: string;
+  /** Slug corrente per evidenziare nella sidebar e calcolare prev/next. */
+  slug?: string;
+}
+
+const { title, description, slug } = Astro.props;
+const { prev, next } = getNavContext(slug ?? '');
+const baseUrl = import.meta.env.BASE_URL;
+---
+
+<BaseLayout title={title} description={description}>
+  <div class="docs-layout">
+    <nav class="docs-sidebar">
+      <div class="docs-sidebar-label">Documenti</div>
+      <ul>
+        {docsNav.map((entry) => (
+          <li class={entry.slug === slug ? 'active' : ''}>
+            <a href={`${baseUrl}docs/${entry.slug}/`}>{entry.title}</a>
+          </li>
+        ))}
+      </ul>
+    </nav>
+
+    <article class="docs-content">
+      <slot />
+
+      {(prev || next) && (
+        <nav class="docs-prevnext">
+          {prev ? (
+            <a href={`${baseUrl}docs/${prev.slug}/`} class="pn-link pn-prev">
+              <span class="pn-label">Precedente</span>
+              <span class="pn-title">{prev.title}</span>
+            </a>
+          ) : <span />}
+          {next ? (
+            <a href={`${baseUrl}docs/${next.slug}/`} class="pn-link pn-next">
+              <span class="pn-label">Successivo</span>
+              <span class="pn-title">{next.title}</span>
+            </a>
+          ) : <span />}
+        </nav>
+      )}
+    </article>
+  </div>
+</BaseLayout>
+
+<style>
+  .docs-layout {
+    display: flex;
+    gap: 2.5rem;
+    align-items: flex-start;
+  }
+
+  /* ---- Sidebar ---- */
+  .docs-sidebar {
+    flex: 0 0 200px;
+    position: sticky;
+    top: 1.5rem;
+  }
+
+  .docs-sidebar-label {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-weight: 600;
+    color: var(--text-tertiary);
+    margin-bottom: 0.75rem;
+  }
+
+  .docs-sidebar ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .docs-sidebar li {
+    margin-bottom: 0.35rem;
+  }
+
+  .docs-sidebar a {
+    display: block;
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: var(--text-secondary);
+    text-decoration: none;
+    padding: 0.3rem 0.5rem;
+    border-radius: var(--radius-sm);
+    transition: all 0.12s;
+    line-height: 1.4;
+  }
+
+  .docs-sidebar a:hover {
+    color: var(--accent);
+    background: var(--accent-light);
+    text-decoration: none;
+  }
+
+  .docs-sidebar .active a,
+  .docs-sidebar .active a:hover {
+    color: var(--accent);
+    background: var(--accent-light);
+    font-weight: 600;
+  }
+
+  /* ---- Content ---- */
+  .docs-content {
+    flex: 1;
+    min-width: 0;
+  }
+
+  /* ---- Prev / Next ---- */
+  .docs-prevnext {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-top: 3rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--border);
+  }
+
+  .pn-link {
+    text-decoration: none;
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    padding: 0.6rem 0.8rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    transition: all 0.12s;
+    flex: 1;
+  }
+
+  .pn-link:hover {
+    border-color: var(--accent);
+    text-decoration: none;
+  }
+
+  .pn-prev {
+    align-items: flex-start;
+  }
+
+  .pn-next {
+    align-items: flex-end;
+    text-align: right;
+  }
+
+  .pn-label {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-weight: 600;
+    color: var(--text-tertiary);
+  }
+
+  .pn-title {
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: var(--text);
+  }
+
+  .pn-link:hover .pn-title {
+    color: var(--accent);
+  }
+
+  /* ---- Mobile ---- */
+  @media (max-width: 700px) {
+    .docs-layout {
+      flex-direction: column;
+      gap: 1.5rem;
+    }
+
+    .docs-sidebar {
+      flex: none;
+      position: static;
+      width: 100%;
+    }
+
+    .docs-sidebar ul {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.35rem;
+    }
+
+    .docs-sidebar li {
+      margin-bottom: 0;
+    }
+
+    .docs-sidebar a {
+      font-size: 0.8rem;
+      padding: 0.25rem 0.5rem;
+      border: 1px solid var(--border);
+      border-radius: var(--radius-sm);
+    }
+
+    .docs-prevnext {
+      flex-direction: column;
+    }
+  }
+</style>

--- a/src/pages/docs/[...slug].astro
+++ b/src/pages/docs/[...slug].astro
@@ -1,5 +1,5 @@
 ---
-import BaseLayout from '../../layouts/BaseLayout.astro';
+import DocsLayout from '../../layouts/DocsLayout.astro';
 
 export async function getStaticPaths() {
   const modules = import.meta.glob('/docs/*.md', { eager: true });
@@ -17,15 +17,14 @@ const { mod } = Astro.props;
 const filename = mod?.file?.split('/')?.pop() ?? '';
 const slug = filename.replace(/\.md$/, '');
 const title = mod?.frontmatter?.title || slug.replace(/-/g, ' ');
+const description = mod?.frontmatter?.description;
 const Content = mod?.Content;
 ---
 
-<BaseLayout title={title}>
+<DocsLayout title={title} description={description} slug={slug}>
   {Content ? (
-    <article>
-      <Content />
-    </article>
+    <Content />
   ) : (
     <p>Contenuto non disponibile.</p>
   )}
-</BaseLayout>
+</DocsLayout>

--- a/src/pages/docs/index.astro
+++ b/src/pages/docs/index.astro
@@ -1,38 +1,11 @@
 ---
-import BaseLayout from '../../layouts/BaseLayout.astro';
-
-const docsModules = import.meta.glob('/docs/*.md', { eager: true });
-
-interface DocMeta {
-  slug: string;
-  title: string;
-}
-
-const docsList: DocMeta[] = Object.entries(docsModules)
-  .map(([filepath, mod]: [string, any]) => {
-    const filename = filepath.split('/').pop() ?? '';
-    const slug = filename.replace(/\.md$/, '');
-    return {
-      slug,
-      title: mod.frontmatter?.title || slug.replace(/-/g, ' '),
-    };
-  })
-  .sort((a, b) => a.slug.localeCompare(b.slug));
+import DocsLayout from '../../layouts/DocsLayout.astro';
 ---
 
-<BaseLayout title="Documenti" description="Documentazione del DataCivicLab">
-  <p class="section-sub">Guide, mappe e procedure per orientarsi nel Lab.</p>
-
-  {docsList.length === 0 && <p><em>Nessun documento ancora pubblicato.</em></p>}
-
-  {docsList.map((entry) => (
-    <div class="card" style="padding: 1.25rem;">
-      <a href={`${import.meta.env.BASE_URL}docs/${entry.slug}/`} style="font-weight: 500; color: var(--text); text-decoration: none;">
-        {entry.title}
-      </a>
-      <div style="font-size: 0.8rem; color: var(--text-tertiary); margin-top: 0.25rem;">
-        {entry.slug}
-      </div>
-    </div>
-  ))}
-</BaseLayout>
+<DocsLayout title="Documenti" description="Guide, mappe e procedure per orientarsi nel Lab.">
+  <h1>Documenti</h1>
+  <p class="section-sub">
+    Guide, mappe e procedure per orientarsi nel DataCivicLab.
+    Usa la sidebar a sinistra per navigare tra le pagine.
+  </p>
+</DocsLayout>


### PR DESCRIPTION
## Sintesi

Sidebar di navigazione per tutte le pagine docs, con glossario e FAQ. Unico posto dove trovare l'elenco completo dei documenti del Lab, la voce attiva evidenziata, e navigazione prev/next.

## Contesto collegato

Nessuna issue — decisione presa in chat con maintainer.

## Cosa cambia

- [ ] Nuova analisi o aggiornamento (analisi/)
- [x] Modifica sito Astro (src/, public/, astro.config.mjs)
- [x] Documenti di orientamento (docs/)
- [ ] Governance / decisioni organizzative
- [ ] Cross-repo task
- [ ] Altro

### Dettaglio

**Layout:**
- `src/layouts/DocsLayout.astro` — layout docs con sidebar sticky + nav prev/next
- `src/data/docs-nav.js` — registro centralizzato ordine e titoli docs
- `src/pages/docs/[...slug].astro` — aggiornato per usare DocsLayout
- `src/pages/docs/index.astro` — semplificato (sidebar basta come navigazione)

**Nuove pagine:**
- `docs/glossario.md` — 17 termini: funnel, layer, candidate, MART, CLEAN, RAW, intake, source-check, toolkit, ecc.
- `docs/domande-frequenti.md` — 11 FAQ da discussion reali: come contribuire, differenza Discussion/Issue, errori, aggiornamento dati, ecc.

**Esistenti migliorate:**
- Aggiunte `description` frontmatter a tutte le pagine docs (per meta tag)

## Checklist

### Se tocchi il sito Astro

- [x] `npm run build` produce `dist/` senza errori
- [x] Nessun warning critico in console durante `npm run dev`
- [x] Layout responsive verificato su mobile (sidebar collassa in row)

### Se tocchi docs/

- [x] Contenuto allineato ai principi del Lab (leggibile da esterni)
- [x] Link funzionanti

## Verifica

- [x] `npm run build` passa (22 pagine, zero errori)
- [x] Sidebar visibile su ogni pagina docs con voce attiva
- [x] Nav prev/next presente in fondo a ogni pagina
- [x] Glossario e FAQ raggiungibili dalla sidebar

## Note per chi revisiona

- Il layout usa `position: sticky` sulla sidebar — su mobile collassa in row di chips
- L'ordine delle pagine è in `src/data/docs-nav.js` — aggiungere una nuova pagina docs basta inserirla lì
- Il `getStaticPaths` in `[...slug].astro` continua a globbare `/docs/*.md` — le nuove pagine vengono trovate automaticamente
