### PR TITLE
feat: setup.sh — bootstrap workspace in un comando

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,5 +93,5 @@ Apri una issue in `dataciviclab` se il lavoro riguarda:
 - [docs/come-contribuire.md](docs/come-contribuire.md) — guida per nuovi contributor
 - [docs/dataset-project-flow.md](docs/dataset-project-flow.md) — flusso dalla domanda all'analisi
 - [docs/governance-model.md](docs/governance-model.md) — ruoli e decisioni
-- [docs/local-setup.md](docs/local-setup.md) — setup tecnico locale
+- [docs/local-setup.md](docs/local-setup.md) — setup tecnico locale (o `curl ... setup.sh | bash`)
 - [`.github`](https://github.com/dataciviclab/.github) — policy condivise

--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,13 @@ SHELL := /bin/bash
 .ONESHELL:
 .PHONY: bootstrap info test lint
 
-VENV := .venv
+# Root della repo dataciviclab (funziona anche via symlink dal workspace)
+ROOT_DIR := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
+VENV := $(ROOT_DIR).venv
 PYTHON := $(VENV)/bin/python
 
 bootstrap:
-	bash scripts/setup.sh --workspace
+	bash $(ROOT_DIR)scripts/setup.sh --workspace
 
 info:
 	@echo "=============================================="

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+# DataCivicLab — Makefile
+#
+# Comandi:
+#   make bootstrap   — setup workspace (clone repo mancanti, installa deps)
+#   make info        — stato workspace
+#   make test        — esegui test di tutti i repo
+#   make lint        — ruff check su tutti i repo
+
+SHELL := /bin/bash
+.ONESHELL:
+.PHONY: bootstrap info test lint
+
+VENV := .venv
+PYTHON := $(VENV)/bin/python
+
+bootstrap:
+	bash scripts/setup.sh --workspace
+
+info:
+	@echo "=============================================="
+	@echo "  DataCivicLab — Workspace Info"
+	@echo "=============================================="
+	@$(PYTHON) --version 2>/dev/null || echo "  .venv non attivo (source .venv/bin/activate)"
+	@echo ""
+	@echo "Repo presenti:"
+	@for d in */; do if [ -f "$$d/.git/HEAD" ]; then echo "  $$d"; fi; done
+
+test:
+	@echo "Esegui: make test-toolkit | make test-di | make test-so | ..."
+
+lint:
+	@echo "Esegui: cd {repo} && ruff check ."

--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ Nasce per chi vuole capire meglio il proprio territorio senza perdersi nel rumor
 
 🌐 **[dataciviclab.org](https://dataciviclab.org)** — sito del Lab con analisi, documenti e stato in tempo reale.
 
+### Setup rapido
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/dataciviclab/dataciviclab/main/scripts/setup.sh | bash
+```
+
+Crea `dataciviclab-workspace/`, clona tutti i repo, installa le dipendenze e configura gli MCP per gli agenti AI.
+
+Serve solo Git e Python 3.12+. Guida completa: [docs/local-setup.md](docs/local-setup.md).
+
 ## Come funziona
 
 | Step | Cosa succede | Dove |

--- a/docs/come-contribuire.md
+++ b/docs/come-contribuire.md
@@ -56,7 +56,17 @@ Per il setup tecnico locale: [local-setup](/docs/local-setup/).
 
 ## Vuoi contribuire con codice
 
-Se sai già programmare e vuoi contribuire direttamente a un repo:
+Se sai già programmare e vuoi contribuire direttamente a un repo, hai due strade:
+
+### Setup rapido (consigliato)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/dataciviclab/dataciviclab/main/scripts/setup.sh | bash -s -- --contributor
+```
+
+Crea `dataciviclab-workspace/`, clona tutti i repo, installa le dipendenze e stampa i comandi per convertire i clone in fork.
+
+### Setup manuale
 
 1. **Forka** il repo su GitHub (tasto `Fork` in alto a destra)
 2. **Clona il tuo fork** in locale
@@ -64,7 +74,7 @@ Se sai già programmare e vuoi contribuire direttamente a un repo:
 4. **Lavora su un branch** — mai direttamente su `main`
 5. **Apri una PR** dal tuo fork al repo originale
 
-Per il setup tecnico dell'ambiente locale: [local-setup](/docs/local-setup/).
+Setup tecnico dettagliato: [local-setup](/docs/local-setup/).
 
 ## Come funzionano le decisioni
 

--- a/docs/local-setup.md
+++ b/docs/local-setup.md
@@ -1,9 +1,9 @@
 ---
-title: Setup locale minimo
+title: Setup locale
 slug: local-setup
-description: Guida tecnica per contributori che vogliono eseguire la pipeline in locale.
+description: Guida tecnica per configurare l'ambiente di lavoro del Lab in un comando.
 ---
-# Setup locale minimo
+# Setup locale
 
 Guida per **contributori esterni** che vogliono lavorare sui dataset del Lab.
 
@@ -12,150 +12,109 @@ Se fai parte del core team, la guida interna è in `lab-ops/operations/local-set
 
 ## Requisiti
 
-- Git
-- Python 3.12+
+- **Git**
+- **Python 3.12+**
 - VS Code (opzionale, ma semplifica)
 
-## 1. Ottieni i repo
-
-### Contributore esterno (vuoi aprire PR)
-
-1. **Forka** ogni repo che ti serve dalla pagina GitHub del Lab.
-   - Esempio: https://github.com/dataciviclab/dataset-incubator → tasto `Fork`
-2. **Clona il tuo fork** (non l'originale):
-
-   ```bash
-   git clone git@github.com:{TUO_USERNAME}/dataset-incubator.git
-   git clone git@github.com:{TUO_USERNAME}/toolkit.git
-   ```
-
-3. **Aggiungi l'originale come upstream** per restare sincronizzato:
-
-   ```bash
-   git remote add upstream git@github.com:dataciviclab/dataset-incubator.git
-   ```
-
-4. Lavora sempre su un **branch**, mai su `main`.
-
-### Hai accesso in scrittura
-
-Clona direttamente i repo dell'organizzazione:
+## Setup rapido (consigliato)
 
 ```bash
-git clone git@github.com:dataciviclab/toolkit.git
-git clone git@github.com:dataciviclab/dataset-incubator.git
+curl -fsSL https://raw.githubusercontent.com/dataciviclab/dataciviclab/main/scripts/setup.sh | bash
 ```
 
-## 2. Struttura workspace
+Lo script:
 
-Metti tutti i repo nella stessa cartella. Esempio:
+1. Crea `dataciviclab-workspace/` nella directory corrente
+2. Clona tutti i repo del Lab (7 core + 7 opzionali)
+3. Crea `.venv` e installa tutte le dipendenze Python
+4. Copia `.env.example` in `.env`
+5. Genera `.mcp.json` con i server MCP del Lab
+
+Tempo stimato: 1-3 minuti (dipende dalla connessione).
+
+### Per contributori (fork)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/dataciviclab/dataciviclab/main/scripts/setup.sh | bash -s -- --contributor
+```
+
+Alla fine stampa i comandi per convertire ogni clone in fork con upstream.
+
+## Setup manuale
+
+Se preferisci non usare lo script o vuoi più controllo:
+
+### 1. Struttura workspace
+
+Metti tutti i repo nella stessa cartella:
 
 ```
 lavoro/
   dataciviclab/
-  dataset-incubator/
   toolkit/
-  lab-connectors/          # dipendenza condivisa (opzionale, vedi sotto)
-  source-observatory/      # scouting fonti (opzionale)
-  agent-context-builder/   # contesto agenti AI (opzionale)
-  data-explorer/           # frontend catalogo — Node.js (opzionale)
+  dataset-incubator/
+  lab-connectors/
+  source-observatory/
+  agent-context-builder/
+  data-explorer/
 ```
 
-Per partire bastano `dataciviclab`, `dataset-incubator` e `toolkit`.
+### 2. Contributore esterno (fork)
 
-## 3. Crea l'ambiente Python
+1. **Forka** ogni repo che ti serve dalla pagina GitHub del Lab (tasto `Fork`)
+2. **Clona il tuo fork**:
+   ```bash
+   git clone git@github.com:{TUO}/dataset-incubator.git
+   ```
+3. **Aggiungi l'upstream** per restare sincronizzato:
+   ```bash
+   git remote add upstream git@github.com:dataciviclab/dataset-incubator.git
+   ```
 
-Dalla root del workspace:
+### 3. Venv e dipendenze
 
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate
-```
-
-**Windows (PowerShell):**
-
-```powershell
-python -m venv .venv
-.venv\Scripts\Activate.ps1
-```
-
-Verifica rapida:
-
-```bash
-python -c "import sys; print(sys.executable)"
-```
-
-Il path deve puntare alla `.venv` del workspace.
-
-## 4. Installa i pacchetti
-
-### Minimo indispensabile — toolkit (include lab-connectors)
-
-```bash
-pip install -e "toolkit[parquet,dev]"
-```
-
-`toolkit` installa automaticamente `lab-connectors` (versione pinnata via git).
-Per un primo run questo basta.
-
-Poi installa `dataset-incubator`:
-
-```bash
-pip install -e "dataset-incubator[dev]"
-```
-
-### Opzionale — editable locale per lab-connectors
-
-Se devi modificare `lab-connectors`, installalo in editable dalla copia locale
-(sovrascrive la versione pinnata installata da toolkit):
-
-```bash
 pip install -e lab-connectors
+pip install -e "toolkit[parquet,dev]"
+pip install --no-deps -e "dataset-incubator[dev]"
+pip install --no-deps -e "source-observatory[dev]"
+pip install -e agent-context-builder[mcp,dev]
+pip install --no-deps -e lab-connectors
 ```
 
-### Opzionale — altri repo
+### 4. Variabili d'ambiente
 
 ```bash
-pip install -e "source-observatory[dev]"
-pip install -e "agent-context-builder[dev]"
+cp dataciviclab/.env.example .env
+# Compila almeno GITHUB_TOKEN
 ```
 
-### Verifica minima
+### 5. Verifica
 
 ```bash
 toolkit --help
 ```
 
-Se non parte, la venv non è attiva o l'installazione non è completa.
+### 6. MCP (per AI agent)
 
-## 5. VS Code (opzionale)
+```bash
+cp dataciviclab/scripts/mcp-servers.json .mcp.json
+# Sostituisci __WORKSPACE__ con il path assoluto del workspace
+```
 
-Il workspace file `dataciviclab.code-workspace` si trova nella repo `dataciviclab`.
+## VS Code (opzionale)
 
-Se hai clonato `dataciviclab`, aprilo con:
+Apri il workspace file incluso in `dataciviclab`:
 
 ```bash
 code dataciviclab/dataciviclab.code-workspace
 ```
 
-Oppure da VS Code: `File → Apri workspace file`.
-
 Include impostazioni consigliate, estensioni e exclude per cache/venv.
 
-## 6. Variabili d'ambiente
-
-Copia il file `.env.example` (nella repo `dataciviclab`) in `.env` nella root del workspace:
-
-```bash
-cp dataciviclab/.env.example .env
-```
-
-Compila almeno `GITHUB_TOKEN` (serve per automazioni e MCP).
-Per eseguire un candidate in locale i token non servono.
-
-## 7. Primo run
-
-Una volta installato tutto, lancia un candidate per verificare che la pipeline funzioni:
+## Primo run
 
 ```bash
 toolkit run all --config dataset-incubator/candidates/irpef-comunale/dataset.yml
@@ -163,13 +122,7 @@ toolkit run all --config dataset-incubator/candidates/irpef-comunale/dataset.yml
 
 Se tutto è a posto vedrai l'output in `dataset-incubator/out/`.
 
-Cosa verifica questo comando:
-- che il toolkit parta e trovi le dipendenze
-- che i path tra repo siano coerenti
-- che la pipeline RAW → CLEAN → MART produca output reali
+## Prossimi passi
 
-## 8. Prossimi passi
-
-- Leggi [come-contribuire](/docs/come-contribuire/) per capire come partecipare
-- Cerca issue `good first issue` per un primo task
-- Quando sei pronto, apri una PR dal tuo fork
+- [come-contribuire](/docs/come-contribuire/) — percorsi per partecipare
+- Issue [`good first issue`](https://github.com/dataciviclab/dataciviclab/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) — primo task

--- a/scripts/mcp-servers.json
+++ b/scripts/mcp-servers.json
@@ -1,0 +1,59 @@
+{
+  "mcpServers": {
+    "toolkit": {
+      "description": "Comandi CLI + diagnostica pipeline",
+      "command": "__WORKSPACE__/.venv/bin/python",
+      "args": ["-m", "toolkit.mcp.server"]
+    },
+    "clean-query": {
+      "description": "Query SQL read-only su dati clean",
+      "command": "__WORKSPACE__/.venv/bin/python",
+      "args": ["__WORKSPACE__/dataset-incubator/tools/clean-query-mcp/server.py"]
+    },
+    "source-observatory": {
+      "description": "Scouting fonti, probe URL, inventory",
+      "command": "__WORKSPACE__/.venv/bin/python",
+      "args": ["__WORKSPACE__/source-observatory/so_mcp/so_server.py"],
+      "cwd": "/tmp"
+    },
+    "dataciviclab-context": {
+      "description": "Bootstrap contesto, topic index, triage",
+      "command": "__WORKSPACE__/.venv/bin/agent-context-mcp",
+      "env": {
+        "ACB_ENV_FILE": "__WORKSPACE__/.env"
+      }
+    },
+    "github-discussions": {
+      "description": "Leggi e cerca discussioni GitHub",
+      "command": "__WORKSPACE__/.venv/bin/python",
+      "args": ["__WORKSPACE__/lab-connectors/mcp_servers/github-discussions/server.py"]
+    },
+    "github": {
+      "description": "API GitHub (issue, PR, repo)",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"]
+    },
+    "fetch": {
+      "description": "Scarica pagine web e API",
+      "command": "npx",
+      "args": ["-y", "mcp-fetch-server"]
+    },
+    "eurostat": {
+      "description": "Query dati Eurostat (NUTS2/NUTS3)",
+      "command": "__WORKSPACE__/.venv/bin/python",
+      "args": ["__WORKSPACE__/eurostat/eurostat-mcp/server.py"],
+      "disabled": true
+    },
+    "siope": {
+      "description": "Bilanci enti pubblici italiani",
+      "command": "__WORKSPACE__/.venv/bin/python",
+      "args": ["__WORKSPACE__/open-siope/mcp_server/server.py"],
+      "disabled": true
+    },
+    "italia-corpus": {
+      "description": "Ricerca legislazione italiana",
+      "command": "__WORKSPACE__/.venv/bin/italia-corpus-mcp",
+      "disabled": true
+    }
+  }
+}

--- a/scripts/mcp-servers.json
+++ b/scripts/mcp-servers.json
@@ -7,14 +7,12 @@
     },
     "clean-query": {
       "description": "Query SQL read-only su dati clean",
-      "command": "__WORKSPACE__/.venv/bin/python",
-      "args": ["__WORKSPACE__/dataset-incubator/tools/clean-query-mcp/server.py"]
+      "command": "__WORKSPACE__/.venv/bin/clean-query-mcp"
     },
     "source-observatory": {
       "description": "Scouting fonti, probe URL, inventory",
-      "command": "__WORKSPACE__/.venv/bin/python",
-      "args": ["__WORKSPACE__/source-observatory/so_mcp/so_server.py"],
-      "cwd": "/tmp"
+      "command": "__WORKSPACE__/.venv/bin/source-observatory-mcp",
+      "timeout": 30000
     },
     "dataciviclab-context": {
       "description": "Bootstrap contesto, topic index, triage",

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -46,7 +46,8 @@ REPOS_PRIVATE=(
 )
 
 WORKSPACE_NAME="dataciviclab-workspace"
-GIT_BASE="git@github.com:"
+# Default: HTTPS (funziona senza auth). Per SSH usa: GIT_BASE="git@github.com:"
+GIT_BASE="https://github.com/"
 GH_BASE="https://github.com/"
 BRANCH="main"
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -177,6 +177,26 @@ copy_env() {
   fi
 }
 
+generate_mcp_config() {
+  local ws="$1"
+  local mcp_file="$ws/.mcp.json"
+  local template="$ws/dataciviclab/scripts/mcp-servers.json"
+
+  if [ -f "$mcp_file" ]; then
+    log_info ".mcp.json già presente"
+    return 0
+  fi
+
+  if [ ! -f "$template" ]; then
+    log_warn "template mcp-servers.json non trovato, salto MCP"
+    return 1
+  fi
+
+  # Sostituisce __WORKSPACE__ con il path reale e scrive .mcp.json
+  sed "s|__WORKSPACE__|$ws|g" "$template" > "$mcp_file"
+  log_info ".mcp.json creato da mcp-servers.json"
+}
+
 print_next_steps() {
   echo ""
   echo -e "${GREEN}==============================================${NC}"
@@ -191,10 +211,14 @@ print_next_steps() {
   echo "  ${CYAN}2.${NC} Modifica .env con i tuoi token:"
   echo "     ${YELLOW}GITHUB_TOKEN${NC} è l'unico obbligatorio"
   echo ""
-  echo "  ${CYAN}3.${NC} Verifica lo stato:"
+  echo "  ${CYAN}3.${NC} Configurazione MCP (per AI agent):"
+  echo "     È stato generato .mcp.json con i server del Lab."
+  echo "     Per OpenCode: copia il contenuto in opencode.json → mcp"
+  echo ""
+  echo "  ${CYAN}4.${NC} Verifica lo stato:"
   echo "     make info"
   echo ""
-  echo "  ${CYAN}4.${NC} Prova una pipeline:"
+  echo "  ${CYAN}5.${NC} Prova una pipeline:"
   echo "     make test"
   echo ""
 }
@@ -272,6 +296,10 @@ workspace_mode() {
   copy_env
 
   echo ""
+  echo -e "${CYAN}🔌 MCP${NC}"
+  generate_mcp_config "$PWD"
+
+  echo ""
   echo -e "${CYAN}✅ Verifica${NC}"
   if [ -d "toolkit" ]; then
     # shellcheck disable=SC1091
@@ -324,6 +352,10 @@ fresh_mode() {
   create_venv
   install_packages
   copy_env
+
+  echo ""
+  echo -e "${CYAN}🔌 MCP${NC}"
+  generate_mcp_config "$PWD"
 
   # Scrivi Makefile se mancante
   if [ ! -f "Makefile" ]; then

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,391 @@
+#!/usr/bin/env bash
+# DataCivicLab — Setup workspace in un comando
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/dataciviclab/dataciviclab/main/scripts/setup.sh | bash
+#   curl -fsSL ... | bash -s -- --contributor
+#
+#   # Se hai già il workspace:
+#   make bootstrap          # dal workspace root
+#   bash dataciviclab/scripts/setup.sh --workspace   # da qualsiasi path
+#
+# Cosa fa:
+#   1. Crea dataciviclab-workspace/ (se non esiste)
+#   2. Clona tutti i repo pubblici del Lab (se mancano)
+#   3. Crea .venv e installa dipendenze
+#   4. Copia .env.example in .env (se manca)
+#   5. Stampa next-steps
+
+set -euo pipefail
+
+# ─── Config ─────────────────────────────────────────────────────────
+REPOS_CORE=(
+  "dataciviclab/dataciviclab"
+  "dataciviclab/toolkit"
+  "dataciviclab/dataset-incubator"
+  "dataciviclab/source-observatory"
+  "dataciviclab/lab-connectors"
+  "dataciviclab/agent-context-builder"
+  "dataciviclab/data-explorer"
+)
+
+REPOS_OPTIONAL=(
+  "dataciviclab/open-siope"
+  "dataciviclab/eurostat"
+  "dataciviclab/italia-corpus"
+  "dataciviclab/senato-akn"
+  "dataciviclab/lab-dashboard"
+  "dataciviclab/progetto-pilota"
+  "dataciviclab/openbdap-saldi-storico-stato"
+)
+
+REPOS_PRIVATE=(
+  "dataciviclab/lab-ops"
+  "dataciviclab/data-advocacy"
+  "dataciviclab/lab-ask"
+)
+
+WORKSPACE_NAME="dataciviclab-workspace"
+GIT_BASE="git@github.com:"
+GH_BASE="https://github.com/"
+BRANCH="main"
+
+# Colori
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; CYAN='\033[0;36m'; NC='\033[0m'
+
+log_info()  { echo -e "${GREEN}✓${NC} $1"; }
+log_step()  { echo -e "${CYAN}→${NC} $1"; }
+log_warn()  { echo -e "${YELLOW}⚠${NC} $1"; }
+log_error() { echo -e "${RED}✗${NC} $1"; }
+
+# ─── Help ────────────────────────────────────────────────────────────
+
+usage() {
+  cat <<USAGE
+DataCivicLab — Setup workspace
+
+Usage:
+  $(basename "$0")              Fresh install (crea workspace, clona, installa)
+  $(basename "$0") --workspace  Già nel workspace: installa/aggiorna dipendenze
+  $(basename "$0") --contributor Come fresh install + istruzioni fork
+  $(basename "$0") --help       Mostra questo help
+USAGE
+  exit 0
+}
+
+# ─── Parse args ──────────────────────────────────────────────────────
+
+MODE="fresh"
+for arg in "$@"; do
+  case "$arg" in
+    --workspace) MODE="workspace" ;;
+    --contributor) MODE="contributor" ;;
+    --help) usage ;;
+  esac
+done
+
+# ─── Utility ─────────────────────────────────────────────────────────
+
+check_command() {
+  if ! command -v "$1" &>/dev/null; then
+    log_error "$1 non trovato. Installa $1 e riprova."
+    exit 1
+  fi
+}
+
+clone_or_skip() {
+  local repo="$1"
+  local dir
+  dir=$(basename "$repo")
+
+  if [ -d "$dir/.git" ]; then
+    log_info "$dir già presente"
+    return 0
+  fi
+
+  log_step "Clone $repo..."
+  if git clone "${GIT_BASE}${repo}.git" "$dir" 2>/dev/null; then
+    log_info "$dir clonato"
+  else
+    log_warn "Impossibile clonare $repo (repo privato o non accessibile?)"
+    return 1
+  fi
+}
+
+create_venv() {
+  if [ -d ".venv" ]; then
+    log_info ".venv già presente"
+    return 0
+  fi
+  log_step "Creazione .venv..."
+  python3 -m venv .venv
+  log_info ".venv creato"
+}
+
+install_packages() {
+  log_step "Attivazione .venv e installazione pacchetti..."
+  source .venv/bin/activate
+
+  # lab-connectors per primo (dipendenza di tutti)
+  if [ -d "lab-connectors" ]; then
+    log_step "lab-connectors..."
+    pip install -q -e lab-connectors
+  fi
+
+  # toolkit
+  if [ -d "toolkit" ]; then
+    log_step "toolkit..."
+    pip install -q -e "toolkit[parquet,dev]"
+  fi
+
+  # agent-context-builder
+  if [ -d "agent-context-builder" ]; then
+    log_step "agent-context-builder..."
+    pip install -q --no-deps -e "agent-context-builder[mcp,dev]"
+  fi
+
+  # dataset-incubator
+  if [ -d "dataset-incubator" ]; then
+    log_step "dataset-incubator..."
+    pip install -q --no-deps -e "dataset-incubator[dev]"
+  fi
+
+  # source-observatory
+  if [ -d "source-observatory" ]; then
+    log_step "source-observatory..."
+    pip install -q --no-deps -e "source-observatory[dev]"
+  fi
+
+  # ripristino lab-connectors (git pin lo sovrascrive)
+  if [ -d "lab-connectors" ]; then
+    pip install -q --no-deps -e lab-connectors
+  fi
+
+  log_info "Dipendenze installate"
+}
+
+copy_env() {
+  if [ -f ".env" ]; then
+    log_info ".env già presente"
+    return 0
+  fi
+  if [ -f "dataciviclab/.env.example" ]; then
+    cp "dataciviclab/.env.example" ".env"
+    log_info ".env creato da .env.example — modificalo con i tuoi token"
+  else
+    log_warn ".env.example non trovato"
+  fi
+}
+
+print_next_steps() {
+  echo ""
+  echo -e "${GREEN}==============================================${NC}"
+  echo -e "${GREEN}  DataCivicLab — Workspace pronto!${NC}"
+  echo -e "${GREEN}==============================================${NC}"
+  echo ""
+  echo "  Prossimi passi:"
+  echo ""
+  echo "  ${CYAN}1.${NC} Attiva l'ambiente virtuale:"
+  echo "     source .venv/bin/activate"
+  echo ""
+  echo "  ${CYAN}2.${NC} Modifica .env con i tuoi token:"
+  echo "     ${YELLOW}GITHUB_TOKEN${NC} è l'unico obbligatorio"
+  echo ""
+  echo "  ${CYAN}3.${NC} Verifica lo stato:"
+  echo "     make info"
+  echo ""
+  echo "  ${CYAN}4.${NC} Prova una pipeline:"
+  echo "     make test"
+  echo ""
+}
+
+print_contributor_steps() {
+  echo ""
+  echo -e "${YELLOW}──────────────────────────────────────────────────${NC}"
+  echo -e "${YELLOW}  Modalità CONTRIBUTOR${NC}"
+  echo -e "${YELLOW}──────────────────────────────────────────────────${NC}"
+  echo ""
+  echo "  Vuoi contribuire? Converti i clone in fork:"
+  echo ""
+  for repo in "${REPOS_CORE[@]}" "${REPOS_OPTIONAL[@]}"; do
+    local dir
+    dir=$(basename "$repo")
+    if [ -d "$dir/.git" ]; then
+      echo "  ${CYAN}●${NC} $dir"
+      echo "    gh repo fork $repo --clone=false"
+      echo "    cd $dir && git remote set-url origin git@github.com:{TUO}/${dir}.git"
+      echo "    git remote add upstream ${GIT_BASE}${repo}.git"
+      echo "    cd .."
+      echo ""
+    fi
+  done
+  echo ""
+  log_warn "Repo privati non forkabili: ${REPOS_PRIVATE[*]}"
+  echo "  Contatta il team se ti servono."
+  echo ""
+}
+
+print_make_bootstrap_instructions() {
+  # Stampa il target make bootstrap se non è già nel Makefile
+  local makefile="Makefile"
+  if [ -f "$makefile" ] && grep -q "^bootstrap:" "$makefile" 2>/dev/null; then
+    return 0  # già presente
+  fi
+  echo ""
+  echo -e "${YELLOW}Suggerimento:${NC} Aggiungi al tuo Makefile:"
+  echo ""
+  echo "  bootstrap:"
+  echo "	bash dataciviclab/scripts/setup.sh --workspace"
+  echo ""
+}
+
+# ─── Modalità: workspace ─────────────────────────────────────────────
+
+workspace_mode() {
+  echo -e "${CYAN}DataCivicLab — Bootstrap workspace${NC}"
+  echo ""
+
+  # Verifica di essere in un workspace valido
+  if [ ! -d "dataciviclab" ]; then
+    log_error "Non sembri essere in un workspace DataCivicLab (manca dataciviclab/)"
+    echo "  Sei nella directory giusta? Dovrebbe contenere dataciviclab/, toolkit/, ..."
+    echo "  Altrimenti usa: $(basename "$0") (senza flag) per una fresh install"
+    exit 1
+  fi
+
+  # Clona repo mancanti
+  echo -e "${CYAN}📦 Repo${NC}"
+  for repo in "${REPOS_CORE[@]}"; do
+    clone_or_skip "$repo"
+  done
+
+  echo ""
+  echo -e "${CYAN}Optional...${NC}"
+  for repo in "${REPOS_OPTIONAL[@]}"; do
+    clone_or_skip "$repo" || true
+  done
+
+  echo ""
+  echo -e "${CYAN}🔧 Ambiente Python${NC}"
+  create_venv
+  install_packages
+  copy_env
+
+  echo ""
+  echo -e "${CYAN}✅ Verifica${NC}"
+  if [ -d "toolkit" ]; then
+    # shellcheck disable=SC1091
+    source .venv/bin/activate 2>/dev/null || true
+    if command -v toolkit &>/dev/null; then
+      echo "   toolkit disponibile — usa: toolkit --help"
+    else
+      log_warn "toolkit non trovato nel PATH (riprova con: make bootstrap)"
+    fi
+  fi
+
+  print_next_steps
+}
+
+# ─── Modalità: fresh install ─────────────────────────────────────────
+
+fresh_mode() {
+  echo -e "${CYAN}DataCivicLab — Fresh install${NC}"
+  echo ""
+
+  # Crea workspace directory
+  if [ ! -d "$WORKSPACE_NAME" ]; then
+    mkdir -p "$WORKSPACE_NAME"
+    log_info "$WORKSPACE_NAME/ creata"
+  else
+    log_info "$WORKSPACE_NAME/ già esiste"
+  fi
+
+  cd "$WORKSPACE_NAME"
+
+  # Verifica git
+  check_command git
+  check_command python3
+
+  # Clona repo
+  echo ""
+  echo -e "${CYAN}📦 Clonazione repo core...${NC}"
+  for repo in "${REPOS_CORE[@]}"; do
+    clone_or_skip "$repo"
+  done
+
+  echo ""
+  echo -e "${CYAN}📦 Clonazione repo opzionali...${NC}"
+  for repo in "${REPOS_OPTIONAL[@]}"; do
+    clone_or_skip "$repo" || true
+  done
+
+  echo ""
+  echo -e "${CYAN}🔧 Ambiente Python${NC}"
+  create_venv
+  install_packages
+  copy_env
+
+  # Scrivi Makefile se mancante
+  if [ ! -f "Makefile" ]; then
+    cat > Makefile << 'MAKEFILE'
+# DataCivicLab — Makefile del workspace
+#
+# Comandi:
+#   make info        — stato workspace
+#   make test        — esegui test
+#   make lint        — ruff check
+#   make bootstrap   — aggiorna workspace (clone mancanti, reinstalla)
+
+SHELL := /bin/bash
+.ONESHELL:
+.PHONY: bootstrap info test lint
+
+VENV := .venv
+PYTHON := $(VENV)/bin/python
+PIP := $(VENV)/bin/pip
+
+bootstrap:
+	bash dataciviclab/scripts/setup.sh --workspace
+
+info:
+	@echo "=============================================="
+	@echo "  DataCivicLab — Workspace Info"
+	@echo "=============================================="
+	@$(PYTHON) --version 2>/dev/null || echo "  .venv non attivo"
+	@echo ""
+	@echo "Repo presenti:"
+	@for d in */; do if [ -f "$$d/.git/HEAD" ]; then echo "  $$d"; fi; done
+
+test:
+	@echo "Usa: make test-toolkit | make test-di | ..."
+	@echo "Oppure: bash dataciviclab/scripts/setup.sh --workspace"
+
+lint:
+	@echo "Usa: cd {repo} && ruff check ."
+MAKEFILE
+    log_info "Makefile creato"
+  fi
+
+  print_next_steps
+
+  if [ "$MODE" = "contributor" ]; then
+    print_contributor_steps
+  fi
+
+  echo ""
+  log_info "Ora entra nel workspace:"
+  echo "  cd $WORKSPACE_NAME"
+  echo "  source .venv/bin/activate"
+}
+
+# ─── Entry point ─────────────────────────────────────────────────────
+
+# Se siamo già in un workspace (rileva dataciviclab/), workspace mode
+if [ "$MODE" = "workspace" ]; then
+  workspace_mode
+elif [ "$MODE" = "fresh" ] && [ -d "dataciviclab" ] && [ -d "toolkit" ]; then
+  # Eseguito da dentro un workspace già esistente
+  workspace_mode
+else
+  fresh_mode
+fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -299,6 +299,12 @@ workspace_mode() {
   echo -e "${CYAN}🔌 MCP${NC}"
   generate_mcp_config "$PWD"
 
+  # Crea Makefile symlink se mancante
+  if [ ! -f "Makefile" ] && [ -f "dataciviclab/Makefile" ]; then
+    ln -s "dataciviclab/Makefile" "Makefile"
+    log_info "Makefile → symlink a dataciviclab/Makefile"
+  fi
+
   echo ""
   echo -e "${CYAN}✅ Verifica${NC}"
   if [ -d "toolkit" ]; then
@@ -357,45 +363,10 @@ fresh_mode() {
   echo -e "${CYAN}🔌 MCP${NC}"
   generate_mcp_config "$PWD"
 
-  # Scrivi Makefile se mancante
-  if [ ! -f "Makefile" ]; then
-    cat > Makefile << 'MAKEFILE'
-# DataCivicLab — Makefile del workspace
-#
-# Comandi:
-#   make info        — stato workspace
-#   make test        — esegui test
-#   make lint        — ruff check
-#   make bootstrap   — aggiorna workspace (clone mancanti, reinstalla)
-
-SHELL := /bin/bash
-.ONESHELL:
-.PHONY: bootstrap info test lint
-
-VENV := .venv
-PYTHON := $(VENV)/bin/python
-PIP := $(VENV)/bin/pip
-
-bootstrap:
-	bash dataciviclab/scripts/setup.sh --workspace
-
-info:
-	@echo "=============================================="
-	@echo "  DataCivicLab — Workspace Info"
-	@echo "=============================================="
-	@$(PYTHON) --version 2>/dev/null || echo "  .venv non attivo"
-	@echo ""
-	@echo "Repo presenti:"
-	@for d in */; do if [ -f "$$d/.git/HEAD" ]; then echo "  $$d"; fi; done
-
-test:
-	@echo "Usa: make test-toolkit | make test-di | ..."
-	@echo "Oppure: bash dataciviclab/scripts/setup.sh --workspace"
-
-lint:
-	@echo "Usa: cd {repo} && ruff check ."
-MAKEFILE
-    log_info "Makefile creato"
+  # Crea Makefile alla root del workspace (symlink a dataciviclab/Makefile)
+  if [ ! -f "Makefile" ] && [ -f "dataciviclab/Makefile" ]; then
+    ln -s "dataciviclab/Makefile" "Makefile"
+    log_info "Makefile → symlink a dataciviclab/Makefile"
   fi
 
   print_next_steps


### PR DESCRIPTION
## Sintesi

Aggiunge `scripts/setup.sh` e `scripts/mcp-servers.json`, lo script che permette a chiunque di configurare il workspace DataCivicLab con un singolo comando:

```bash
curl -fsSL https://raw.githubusercontent.com/dataciviclab/dataciviclab/main/scripts/setup.sh | bash
```

Include anche `make bootstrap` nel Makefile del workspace e aggiorna tutta la documentazione (README, local-setup, come-contribuire, CONTRIBUTING).

## Cosa cambia

- [x] Nuovi script (scripts/setup.sh, scripts/mcp-servers.json)
- [x] Documenti di orientamento (docs/)
- [ ] Governance / decisioni organizzative
- [ ] Cross-repo task
- [x] Altro: Makefile workspace root

## Checklist docs/

- [x] Contenuto allineato ai principi del Lab (leggibile da esterni)
- [x] Link funzionanti

## Verifica

- [x] `bash scripts/setup.sh --workspace` testato sul workspace reale
- [x] `make bootstrap` funzionante
- [x] `.mcp.json` generato correttamente (JSON valido)
- [x] Pre-commit hooks passati (trim trailing whitespace, fix end of files, check json)
- [x] Perimetro piccolo e leggibile

## Note per chi revisiona

- Lo script supporta tre modalità: fresh install (`curl | bash`), workspace (`--workspace`), contributor (`--contributor`)
- Il template MCP (`mcp-servers.json`) usa `__WORKSPACE__` come placeholder sostituito dallo script
- Il Makefile del workspace root non è tracciato in git (è locale) — è stato aggiornato a mano
- I repo privati (lab-ops, data-advocacy, lab-ask) vengono ignorati dallo script