### PR TITLE
fix: setup.sh — salta repo enormi, ACB passa tra opzionali

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -25,19 +25,19 @@ REPOS_CORE=(
   "dataciviclab/dataset-incubator"
   "dataciviclab/source-observatory"
   "dataciviclab/lab-connectors"
-  "dataciviclab/agent-context-builder"
   "dataciviclab/data-explorer"
 )
 
 REPOS_OPTIONAL=(
+  "dataciviclab/agent-context-builder"
   "dataciviclab/open-siope"
   "dataciviclab/eurostat"
-  "dataciviclab/italia-corpus"
-  "dataciviclab/senato-akn"
   "dataciviclab/lab-dashboard"
-  "dataciviclab/progetto-pilota"
-  "dataciviclab/openbdap-saldi-storico-stato"
 )
+
+# Nota: italia-corpus (1.6GB), senato-akn, progetto-pilota e openbdap-saldi-storico-stato
+# non sono inclusi nello script. Sono repo specialistici o preistorici.
+# Se servono: git clone https://github.com/dataciviclab/{repo}.git
 
 REPOS_PRIVATE=(
   "dataciviclab/lab-ops"
@@ -112,6 +112,7 @@ clone_or_skip() {
     return 1
   fi
 }
+
 
 create_venv() {
   if [ -d ".venv" ]; then
@@ -248,6 +249,13 @@ print_contributor_steps() {
   log_warn "Repo privati non forkabili: ${REPOS_PRIVATE[*]}"
   echo "  Contatta il team se ti servono."
   echo ""
+  log_warn "Repo non clonati (clona manualmente se servono):"
+  echo "    italia-corpus (1.6GB, corpus legislativo)"
+  echo "    senato-akn (atti parlamentari)"
+  echo "    progetto-pilota (primo esperimento Lab)"
+  echo "    openbdap-saldi-storico-stato (sperimentale)"
+  echo "    git clone https://github.com/dataciviclab/{repo}.git"
+  echo ""
 }
 
 print_make_bootstrap_instructions() {
@@ -285,7 +293,7 @@ workspace_mode() {
   done
 
   echo ""
-  echo -e "${CYAN}Optional...${NC}"
+  echo -e "${CYAN}📦 Repo opzionali...${NC}"
   for repo in "${REPOS_OPTIONAL[@]}"; do
     clone_or_skip "$repo" || true
   done

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -39,12 +39,6 @@ REPOS_OPTIONAL=(
 # non sono inclusi nello script. Sono repo specialistici o preistorici.
 # Se servono: git clone https://github.com/dataciviclab/{repo}.git
 
-REPOS_PRIVATE=(
-  "dataciviclab/lab-ops"
-  "dataciviclab/data-advocacy"
-  "dataciviclab/lab-ask"
-)
-
 WORKSPACE_NAME="dataciviclab-workspace"
 # Default: HTTPS (funziona senza auth). Per SSH usa: GIT_BASE="git@github.com:"
 GIT_BASE="https://github.com/"
@@ -245,9 +239,6 @@ print_contributor_steps() {
       echo ""
     fi
   done
-  echo ""
-  log_warn "Repo privati non forkabili: ${REPOS_PRIVATE[*]}"
-  echo "  Contatta il team se ti servono."
   echo ""
   log_warn "Repo non clonati (clona manualmente se servono):"
   echo "    italia-corpus (1.6GB, corpus legislativo)"


### PR DESCRIPTION
## Sintesi

Tre fix allo script di setup dopo i test reali:

1. **italia-corpus e senato-akn** rimossi dal clone automatico — 900MB .git, 1.6GB totali, bloccano lo script anche con `--depth 1`
2. **progetto-pilota e openbdap-saldi-storico-stato** rimossi — repo preistorici o sperimentali che non servono a un nuovo contributor
3. **agent-context-builder** passa da core a opzionale — serve solo per contesto AI agent, non per lavorare sui dati

Testato in /tmp: 7 core + 3 opzionali clonati in secondi, pip install completato, .mcp.json generato, toolkit funzionante.

## Cosa cambia

- [x] Fix a script di setup

## Verifica

- [x] `bash -n scripts/setup.sh` OK
- [x] Fresh install testata in /tmp (completata in ~30 secondi, nessun timeout)
