### PR TITLE
chore(registry): lab-stats.js legge registry.json (fusion) — drop clean_catalog

### DIFF
--- a/src/lib/lab-stats.js
+++ b/src/lib/lab-stats.js
@@ -5,24 +5,24 @@
  */
 
 const CATALOG_URL =
-  "https://raw.githubusercontent.com/dataciviclab/dataset-incubator/main/registry/clean_catalog.json";
+  "https://raw.githubusercontent.com/dataciviclab/dataset-incubator/main/registry/registry.json";
 
 const RADAR_URL =
   "https://raw.githubusercontent.com/dataciviclab/source-observatory/main/data/radar/radar_summary.json";
 
 /** Dati fallback (ultimi valori noti, usati se GitHub raw non risponde) */
-const FALLBACK_CATALOG = { total: 19, published: 7, incubating: 12 };
+const FALLBACK_CATALOG = { total: 114, published: 97, incubating: 17 };
 const FALLBACK_RADAR = { total: 14, green: 8, yellow: 3, red: 3 };
 
 /**
- * Legge clean_catalog.json e restituisce conteggi per stage.
+ * Legge registry.json e restituisce conteggi per stage.
  * @returns {{ total: number, published: number, incubating: number }}
  */
 export async function fetchCatalogStats() {
   try {
     const res = await fetch(CATALOG_URL);
     if (!res.ok) {
-      console.warn("[lab-stats] clean_catalog.json non raggiungibile, uso fallback");
+      console.warn("[lab-stats] registry.json non raggiungibile, uso fallback");
       return FALLBACK_CATALOG;
     }
     const data = await res.json();
@@ -33,7 +33,7 @@ export async function fetchCatalogStats() {
       incubating: datasets.filter((d) => d.stage === "incubating").length,
     };
   } catch (err) {
-    console.warn("[lab-stats] clean_catalog.json fetch fallito:", err.message, "— uso fallback");
+    console.warn("[lab-stats] registry.json fetch fallito:", err.message, "— uso fallback");
     return FALLBACK_CATALOG;
   }
 }
@@ -65,7 +65,7 @@ export async function fetchRadarStats() {
 }
 
 /**
- * Legge clean_catalog.json e restituisce un Set di slug dei dataset pubblicati.
+ * Legge registry.json e restituisce un Set di slug dei dataset pubblicati.
  * Utile per verificare se un'analisi ha un dataset corrispondente su explorer.
  * Se il fetch fallisce, ritorna Set vuoto (nessun badge "Su Explorer" mostrato).
  * @returns {Promise<Set<string>>}


### PR DESCRIPTION
## Sintesi

Migra il loader KPI del sito pubblico (`src/lib/lab-stats.js`, usato da `ecosistema.astro`) da `clean_catalog.json` (proiezione legacy di dataset-incubator, rimossa) a `registry.json` (fusion ADR).

## Contesto collegato

- DI rimuove le proiezioni legacy (`clean_catalog.json`/`pipeline_signals.json`/`entity_graph.json`) — dataset-incubator PR #818
- Questo è l'ultimo consumer del sito che legge il file legacy

## Cosa cambia

- `src/lib/lab-stats.js`:
  - URL → `registry/registry.json`
  - `FALLBACK_CATALOG` aggiornato ai conteggi reali (114 totali / 97 published / 17 incubating — era 19/7/12, stale)
  - commenti/warning aggiornati
  - parsing invariato (`data.datasets` con `stage` — struttura identica)

## Impatto

- [ ] Modifica analisi / dataset
- [ ] Modifica sito (componente, layout)
- [x] Modifica loader dati build-time
- [ ] Documentazione

> Nessun cambio di output per il sito: i conteggi restano gli stessi (dal registry). Solo la fonte cambia da proiezione legacy ad artifact canonico.

## Verifica

- La pagina `ecosistema.astro` usa `fetchCatalogStats()`/`fetchPublishedSlugs()` — parsing `data.datasets`/`stage` invariato, compatibile con registry.json
- Fallback mantenuto (degradazione senza crash se GitHub raw non risponde)

- [x] Perimetro stretto: solo loader lab-stats.js
